### PR TITLE
Split check_blastfile utility into two generically-named functions

### DIFF
--- a/src/check_benign.py
+++ b/src/check_benign.py
@@ -23,7 +23,7 @@ def check_for_benign(query, coords, benign_desc):
     # PROTEIN HITS
     # for each set of hits, need to pull out the coordinates covered by benign entries
     hmmscan = query + ".benign.hmmscan"
-    if check_blastfile(hmmscan) == 2:
+    if not has_hits(hmmscan):
         sys.stdout.write("\t...no housekeeping protein hits\n")
     else:
         hmmer = readhmmer(hmmscan)
@@ -68,7 +68,7 @@ def check_for_benign(query, coords, benign_desc):
     # RNA HITS
     # for each set of hits, need to pull out the coordinates covered by benign entries
     cmscan = query + ".benign.cmscan"
-    if check_blastfile(cmscan) == 2:
+    if not has_hits(cmscan):
         sys.stdout.write("\t...no benign RNA hits\n")
     else:
         cmscan = readcmscan(cmscan)
@@ -115,7 +115,7 @@ def check_for_benign(query, coords, benign_desc):
     # SYNBIO HITS
     # annotate and clear benign nucleotide sequences
     blast = query + ".benign.blastn"
-    if check_blastfile(blast) == 2:
+    if not has_hits(blast):
         sys.stdout.write("\t...no Synbio sequence hits\n")
     else:
         blastn = readblast(blast) # synbio parts

--- a/src/check_biorisk.py
+++ b/src/check_biorisk.py
@@ -38,10 +38,9 @@ def main():
     # print(lookup)
 
     # read in HMMER output and check for valid hits
-    res = check_blastfile(in_file)
-    if res == 0:
+    if is_empty(in_file):
         sys.stdout.write("\t...ERROR: biorisk search results empty\n")
-    if res == 1:
+    if has_hits(in_file):
         hmmer = readhmmer(in_file)
         keep1 = [i for i, x in enumerate(hmmer['E-value']) if x < 1e-20]
         hmmer = hmmer.iloc[keep1,:]
@@ -69,7 +68,7 @@ def main():
                     sys.stdout.write("\t\t --> Virulence factor found in bases " + str(hmmer['ali from'][region]) + " to " + str(hmmer['ali to'][region]) + ", WARNING\n\t\t     Gene: " + ", ".join(set(hmmer['description'][hmmer['Must flag'] == False])) + "\n")
         else: 
             sys.stdout.write("\t\t --> Biorisks: no significant hits detected, PASS\n")
-    if res == 2:
+    else:
         sys.stdout.write("\t\t --> Biorisks: no hits detected, PASS\n")
 
 if __name__ == "__main__":

--- a/src/check_reg_path.py
+++ b/src/check_reg_path.py
@@ -53,10 +53,10 @@ def main():
     if os.path.exists(sample_name + ".reg_path_coords.csv"):
         hits1 = pd.read_csv(sample_name + ".reg_path_coords.csv")
 
-    if check_blastfile(args.in_file) == 0:
+    if is_empty(args.in_file):
         sys.stdout.write("\tERROR: Homology search has failed\n")
         exit(1)
-    if check_blastfile(args.in_file) == 2:
+    if not has_hits(args.in_file):
         sys.stdout.write("\t...no hits\n")
         exit(1)
     blast = readblast(args.in_file)                  #function in utils.py

--- a/src/fetch_nc_bits.py
+++ b/src/fetch_nc_bits.py
@@ -14,9 +14,9 @@ f_file = sys.argv[2]
 nc_bits = 0
 
 # check if the nr hits file is empty
-if check_blastfile(query) == 0:
+if is_empty(query):
     nc_bits = "all"
-elif check_blastfile(query) == 2:
+elif not has_hits(query):
     sys.stdout.write("\t...no hits to the nr database\n")
     nc_bits = "all"
 # if not, check whether any of the hits has an E-value > 1e-30

--- a/src/process_outputs.py
+++ b/src/process_outputs.py
@@ -121,9 +121,9 @@ def plothits(starts, ends, qlen, names, colours, nhits, max):
 
 # plot HMMER results from --domtblout
 def plot_hmmer(file, lookup, nhits=10):
-    if check_blastfile(file) == 0:
+    if is_empty(file):
         return
-    if check_blastfile(file) == 2:
+    if not has_hits(file):
 		# generate empty plot saying "no hits"
         fig = plt.figure(figsize=(10,3))
         ax = fig.add_subplot(111, frameon=False)
@@ -163,9 +163,9 @@ def plot_hmmer(file, lookup, nhits=10):
 
 # plot BLAST results
 def plot_blast(file, reg_ids, vax_ids, nhits):
-    if check_blastfile(file) == 0:
+    if is_empty(file):
         return
-    if check_blastfile(file) == 2:
+    if not has_hits(file):
 		# generate empty plot saying "no hits"
         fig = plt.figure(figsize=(10,3))
         ax = fig.add_subplot(111, frameon=False)
@@ -215,9 +215,9 @@ def plot_blast(file, reg_ids, vax_ids, nhits):
 
 # plot BLAST results from fragmented noncoding file
 def plot_blast_frag(file, reg_ids, vax_ids, nhits):
-    if check_blastfile(file) == 0:
+    if is_empty(file):
         return
-    if check_blastfile(file) == 2:
+    if not has_hits(file):
 		# generate empty plot saying "no hits"
         fig = plt.figure(figsize=(10,3))
         ax = fig.add_subplot(111, frameon=False)

--- a/src/utils.py
+++ b/src/utils.py
@@ -24,30 +24,35 @@ import pytaxonkit
 
 
 ##############################################################################
-#check_blastfile 
-#usage: check BLAST output files for each query to see if they exist and have any hits
+#is_empty
+#usage: check that a file is empty
 #input: 
-#   - name of BLAST output file  
-def check_blastfile(filename):
-    if os.path.isfile(filename) == False:
-        # sys.stderr.write("\t...%s does not exist\n" % filename)
-        return 0
-    curr_file = open(filename,'r')
-    num_hits = 0 
-    num_lines = 0
-    for line in curr_file:
-        if (len(line) > 0) and (line[0] != "#"):
-            num_hits += 1
-        num_lines += 1
-    #Return based on file results
-    if num_lines == 0:
-        # sys.stderr.write("\t...%s is empty\n" % filename)
-        return 0
-    elif num_hits == 0:
-        # sys.stderr.write("\t...%s has no hits\n" % filename)
-        return 2        
-    else:
-        return 1
+#   - name of file  
+def is_empty(filepath: str) -> bool:
+    try:
+        abspath = os.path.abspath(os.path.expanduser(filepath))
+        return os.path.getsize(abspath) == 0
+    except OSError:
+        # If there is an error (including FileNotFoundError) consider it empty
+        return True
+
+##############################################################################
+#has_hits 
+#usage: check to see if the file contains any hits (lines that don't start with #)
+#input: 
+#   - path to file 
+def has_hits(filepath: str) -> bool:
+    try:
+        with open(filepath,'r') as file:
+            for line in file:
+                # Strip leading and trailing whitespace and check the first character
+                if not line.strip().startswith('#'):
+                    # Found a hit!
+                    return True
+        return False
+    except FileNotFoundError:
+        # The file does not exist
+        return False
 
 ##############################################################################
 #colourscale 


### PR DESCRIPTION
We ran into an issue in testing due to not running a check about whether a file exists. My hope is that making the check_blastfile utility more explicit, we'll be able to avoid this kind of error in future.
 
```
 >> STEP 4: Checking any pathogen regions for benign components...
Traceback (most recent call last):
  File "nti/CommonMechanism/src/check_benign.py", line 177, in <module>
        ...no housekeeping protein hits
    main()
  File "nti/CommonMechanism/src/check_benign.py", line 172, in main
    check_for_benign(args.sample_name, coords, benign_desc)
  File "nti/CommonMechanism/src/check_benign.py", line 74, in check_for_benign
    cmscan = readcmscan(cmscan)
             ^^^^^^^^^^^^^^^^^^
  File "nti/CommonMechanism/src/utils.py", line 262, in readcmscan
    with open(fileh, 'r') as f:
         ^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'A22393.1_200_573_772_rs.fa.benign.cmscan'
 >> COMPLETED AT Sun Mar  3 18:10:39 EST 2024
```