### PR TITLE
Bugfix 0.1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,32 @@
-## What type of PR is this? (check all applicable)
-
-- [ ] Refactor
-- [ ] Feature
-- [ ] Bug Fix
-- [ ] Optimization
-- [ ] Documentation Update
-
-## What does this implement/fix? Explain your changes.
+# Description
 <!--
 Leave a gift for your future self about what this PR was.
+
+Please include a summary of the changes, as well as relevant motivation and context.
+
+List any dependencies that are required for this change.
 -->
 
-## Does this relate to any currently open issues?
 <!--
-For pull requests that relate or close an issue, please include them below.
-
-Having the text: "closes #1234" would connect the current pull request to
-issue 1234. You can also use the Github keywords [fix/es, resolve/s].
-When we close the pull request, Github will automatically close the issue.
-
-Do not use those keywords to if this pull request does not fully resolve the
-issue!
+Does this relate to any open issues? Please include them, or delete the line below.
 -->
+**Issues**:
+<!--
+Having the text: "#1234" would connect the current pull request to issue 1234.
+
+You can use the Github keywords [fix/es, resolve/s], but this will automatically
+close the issue, so only do so if the PR fully resolves them!
+-->
+
+## Type of change
+<!--
+Please delete options that are not relevant.
+-->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor (non-breaking change to code or documentation which should not change functionality)
 
 ## Are there any relevant logs, error output, etc?
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Please delete options that are not relevant.
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactor (non-breaking change to code or documentation which should not change functionality)
 
-## Are there any relevant logs, error output, etc?
+## Relevant logs, error messages, etc.
 <!--
 This will help to find this PR message in future if similar errors appear.
 -->

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -121,7 +121,7 @@ def get_cleaned_fasta(input_file, out_prefix):
     """
     Return a FASTA where whitespace (including non-breaking spaces) is replaced with underscores.
     """
-    cleaned_file = f"{out_prefix}.fasta"
+    cleaned_file = f"{out_prefix}.cleaned.fasta"
     with (
         open(input_file, "r", encoding="utf-8") as fin,
         open(cleaned_file, "w", encoding="utf-8") as fout,

--- a/commec/screen_databases.py
+++ b/commec/screen_databases.py
@@ -40,7 +40,7 @@ class ScreenDatabases:
     @property
     def nr_db(self):
         if self.search_tool == "blastx":
-            return os.path.join(self.nr_dir, "swissprot")
+            return os.path.join(self.nr_dir, "nr")
         elif self.search_tool == "diamond":
             return os.path.join(self.nr_dir, "nr.dmnd")
         else:


### PR DESCRIPTION
Fix two bugs that appeared when testing v0.1.0 of the `commec` package.

A BLAST error related to being unable to find the `swissprot` database... which caused me to realize that the smaller database I had been using for testing was still hardcoded somewhere (oops).

Also had an issue when not specifying an output directory and also calling `commec screen` from inside the directory where my input files were; this led to trying to read and write the input FASTA at the same time while cleaning, which messed up the file (fair enough).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)