### PR TITLE
Updated conda recipe.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,41 +1,48 @@
-{% set version = "0.1.0" %}
+
+{% set name = "commec" %}
+{% set version = "0.1.2" %}
+{% set sha256 = "33e99060dca151cb9d5481f47e02f1b5276b2cdf61804e7093f0cfc32bef1188" %}
 
 package:
-  name: commec
-  version: {{ version }}
+  name: "{{ name }}"
+  version: "{{ version }}"
 
 source:
-  path: ../  # Adjust as necessary
+  url: https://github.com/ibbis-screening/common-mechanism/archive/refs/tags/v{{version}}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
+  run_exports:
+    # consider using "x.x.x" rather than "x.x", or "x" considering alpha software and liklihood of change.
+    - {{ pin_subpackage('commec', max_pin="x.x") }}
 
 requirements:
   build:
-    - python
-    - pip
+    - python >=3.1
+    - pip >=24
   host:
-    - python
-    - pip
+    - python >=3.1
+    - pip >=24
   run:
-    - python
+    - python >=3.1
     # Runtime Python dependencies
-    - biopython
-    - numpy
-    - pandas
-    - pytaxonkit
+    - biopython >=1.8
+    - numpy >=2.0.0
+    - pandas >=2.2
+    - pytaxonkit >=0.8
     # Runtime non-Python dependencies
-    - bedtools
-    - blast
-    - emboss
-    - diamond
-    - hmmer
-    - infernal
-    - parallel
-    - perl-list-moreutils
-    - taxonkit
-    - python
+    - bedtools >=2.31
+    - blast >=2.16
+    - emboss >=6.6
+    - diamond >=0.9
+    - hmmer >=3.4
+    - infernal >=1.1
+    - parallel >=20240722
+    - perl-list-moreutils >=0.430
+    - taxonkit >=0.17
 
 test:
   commands:
@@ -46,4 +53,6 @@ test:
 about:
   home: https://github.com/ibbis-screening/common-mechanism
   license: MIT
+  license_family: MIT
+  doc_url: https://github.com/ibbis-screening/common-mechanism/wiki
   summary: "commec: a free, open-source, globally available tool for DNA sequence screening"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   run_exports:
-    # consider using "x.x.x" rather than "x.x", or "x" considering alpha software and liklihood of change.
+    # consider using "x.x.x" rather than "x.x", or "x" considering alpha software and likelihood of change.
     - {{ pin_subpackage('commec', max_pin="x.x") }}
 
 requirements:


### PR DESCRIPTION

# Description
Update to conda recipe, to pass local linting and build from bioconda-utils tool. ready for testing with Pull Request into bioconda-recipes repo.

changes:
* Add run_exports field to support others referencing commec versions.
* Add noarch python
* Add minimum versioning for all requirements.
* added Sha256 hash for download confirmation
* Added tagged 0.1.2 tar download for commec as stable URL.

