### PR TITLE
Provide Diamond with --jobs, not "--processes"

### DIFF
--- a/commec/run_blastx.sh
+++ b/commec/run_blastx.sh
@@ -10,7 +10,7 @@ set -eu
 DB=""
 QUERY=""
 OUTPUT="out" 
-THREADS=1           #threads per process
+THREADS=1
 FURTHEROPT=""
 
 #Get options from user

--- a/commec/run_diamond.sh
+++ b/commec/run_diamond.sh
@@ -1,89 +1,89 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # Copyright (c) 2021-2024 International Biosecurity and Biosafety Initiative for Science
 #####################################################################
-#run_diamond.sh runs DIAMOND against a specified NCBI nr database. 
+# run_diamond.sh runs DIAMOND against a specified NCBI nr database.
+# DIAMOND citation: 
 #   Buchfink B, Reuter K, Drost HG, "Sensitive protein alignments at 
 #   tree-of-life scale using DIAMOND", 
 #   Nature Methods 18, 366–368 (2021). 
 #   doi:10.1038/s41592-021-01101-x
-#Script Author: Jennifer Lu, jennifer.lu717@gmail.com
-#Updated: 05/25/2022 
-##################################################################### 
+#####################################################################
 
-#set -eux #debug mode
 set -eu
-PROCESSES=5         #number of processes to run at once 
-THREADS=1           #threads per process  
+
+# Default values
+JOBS=""
+THREADS=1
 DB_PATH=""
 INPUT=""
-OUTPUT="out" 
+OUTPUT="out"
 
-#Get options from user
-while getopts "p:t:d:i:o:" OPTION
-    do 
-        case $OPTION in
-            p) 
-                PROCESSES=$OPTARG
-                ;;
-            t) 
-                THREADS=$OPTARG
-                ;;
-            d) 
-                DB_PATH=$OPTARG
-                ;;
-            i) 
-                INPUT=$OPTARG
-                ;;
-            o) 
-                OUTPUT=$OPTARG
-                ;;
-            \?)
-                echo "Usage: run_diamond.sh -d MY_DB -i INPUT_FILE -o OUTPUT_FILE [-p PROCESSES -t THREADS]"
-                echo "  MY_DB           location of NCBI nr database (required)"
-                echo "  INPUT_FILE      input file to align to each database (required)" 
-                echo "  OUTPUT_FILE     output prefix for alignments (default: out)" 
-                echo "  PROCESSES       number of databases to evaluate (default: 5)"
-                echo "  THREADS         number of threads for each database run (default: 1)"
-                exit 
-                ;;  
-        esac 
-    done
-
-#Check for values
-if [ "$DB_PATH" == "" ] && [ "$INPUT" == "" ]
-then
-    echo "Usage: run_diamond.sh -d MY_DB -i INPUT_FILE -o OUTPUT_FILE [-p PROCESSES -t THREADS]"
+usage() {
+    echo "Usage: run_diamond.sh -d MY_DB -i INPUT_FILE [-o OUTPUT_FILE] [-j JOBS] [-t THREADS]"
     echo "  MY_DB           location of NCBI nr database (required)"
     echo "  INPUT_FILE      input file to align to each database (required)" 
     echo "  OUTPUT_FILE     output prefix for alignments (default: out)" 
-    echo "  PROCESSES       number of databases to evaluate (default: 5)"
-    echo "  THREADS         number of threads for each database run (default: 1)"
-    exit 
-fi
-#Check for database 
-echo -e "\t...checking options for diamond"
-if [ -d $DB_PATH ]
-then 
-    #Directory exists, check for at least one diamond db file 
-    if [ ! -f $DB_PATH/nr.1.dmnd ] 
-    then 
-        echo -e "\t...ERROR: nr diamond database $DB_PATH/nr.1.dmnd does not exist"
-        exit
-    fi
-else
-    echo -e "\t...ERROR: nr diamond database folder $DB_PATH does not exist" 
-    exit
-fi
-  
-#Check for input file 
-if [ ! -f  $INPUT ] 
-then
-    echo -e "\t...ERROR: input file $INPUT does not exist" 
-    exit
-fi      
+    echo "  JOBS            number of diamond runs to do in parallel (default: # CPUs / THREADS)"
+    echo "  THREADS         number of threads for each diamond run (default: 1)"
+    exit 1
+}
 
-echo -e "\t...running diamond protein search"
-ls ${DB_PATH}/nr*.dmnd | parallel --will-cite -j ${PROCESSES} diamond blastx --quiet -d ${DB_PATH}/nr.{%}.dmnd --threads ${THREADS} -q ${INPUT} -o ${OUTPUT}.{%}.tsv --outfmt 6 qseqid stitle sseqid staxids evalue bitscore pident qlen qstart qend slen sstart send --frameshift 15 --range-culling
+# Parse command line arguments
+while getopts "j:t:d:i:o:" opt; do
+    case $opt in
+        j) JOBS=$OPTARG ;;
+        t) THREADS=$OPTARG ;;
+        d) DB_PATH=$OPTARG ;;
+        i) INPUT=$OPTARG ;;
+        o) OUTPUT=$OPTARG ;;
+        \?) usage ;;
+    esac
+done
+
+# Check for required arguments
+if [[ -z "$DB_PATH" || -z "$INPUT" ]]; then
+    usage
+fi
+
+# Validate input
+if [[ ! -d "$DB_PATH" ]]; then
+    echo "ERROR: nr diamond database folder $DB_PATH does not exist" >&2
+    exit 1
+fi
+
+shopt -s failglob
+if ! files=("${DB_PATH}"/nr*.dmnd); then
+    echo "ERROR: No nr diamond database files (nr*.dmnd) found in $DB_PATH" >&2
+    exit 1
+fi
+shopt -u failglob
+
+if [[ ! -f "$INPUT" ]]; then
+    echo "ERROR: input file $INPUT does not exist" >&2
+    exit 1
+fi
+
+# Set JOBS if not specified by user
+if [[ -z "$JOBS" ]]; then
+    CPU_COUNT=$(parallel --number-of-cpus)
+    JOBS=$((CPU_COUNT / THREADS))
+fi
+
+echo "Running diamond protein search..."
+echo "Using $JOBS job(s) in parallel with $THREADS thread(s) each"
+
+# Run diamond
+ls ${DB_PATH}/nr*.dmnd | parallel --will-cite --use-cpus-instead-of-cores --jobs ${JOBS} \
+    diamond blastx --quiet \
+    -d {} \
+    --threads ${THREADS} \
+    -q ${INPUT} \
+    -o ${OUTPUT}.{/.}.tsv \
+    --outfmt 6 qseqid stitle sseqid staxids evalue bitscore pident qlen qstart qend slen sstart send \
+    --frameshift 15 --range-culling
+
+# Combine results and clean up
 cat ${OUTPUT}.*.tsv > ${OUTPUT}.dmnd
 rm ${OUTPUT}.*.tsv
 
+echo "Diamond protein search completed. Results are in ${OUTPUT}.dmnd"


### PR DESCRIPTION
# Description
When investigating the inconsistent `--processes` tag, I realised that `run_diamond.sh` was not written in a robust way, and "processes" is not a good description of its function.

Specifically, in this command (pulled out the parts not relevant to parallelization):

```bash
ls ${DB_PATH}/nr*.dmnd | parallel -j ${PROCESSES}
diamond blastx --quiet -d ${DB_PATH}/nr.{%}.dmnd \
--threads ${THREADS} -o ${OUTPUT}.{%}.tsv
```

* `PROCESSES` is not really "processes", it's the number of jobs we tell parallel to run at once
* we use the `{%}` replacement string, which is the job number, to decide which database we use in `--d`... I think they way we've set this up we need to literally always be counting from 1-6. (which is what `screen.py` was doing, but not `run_pipeline.sh`). Based on some local testing of parallel, if we were running with only 2 processes, then the outputs would get (I think? not sure what diamond does with pre-existing output files) overwritten

I have changed this to set the number of jobs to run in parallel based on the threads and CPUs (unless a number is supplied) and made some other parts of run_diamond a bit more robust, then propagated those changes.

**Issues**:
Addresses #10, though we'll need to change the wiki once this is released

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) _(well, it's a breaking change to run_pipeline, but not to commec screen, which is the preferred interface)_