### PR TITLE
Bugfix: filter out deleted and invalid taxonomy ids

### DIFF
--- a/commec/screeners/check_benign.py
+++ b/commec/screeners/check_benign.py
@@ -15,15 +15,16 @@ import os
 import sys
 import pandas as pd
 
-from commec.tools.blastn import BlastNHandler # For has_hits.
-from commec.tools.blast_tools import get_top_hits, readblast, _trim_overlapping
+from commec.tools.blastn import BlastNHandler  # For has_hits.
+from commec.tools.blast_tools import get_top_hits, read_blast
 from commec.tools.hmmer import readhmmer
 from commec.tools.cmscan import readcmscan
 
+
 def check_for_benign(query, coords, benign_desc):
-    '''
-    Checks a query against taxonomy 
-    '''
+    """
+    Checks a query against taxonomy
+    """
     cleared = [0] * coords.shape[0]
 
     # PROTEIN HITS
@@ -55,8 +56,12 @@ def check_for_benign(query, coords, benign_desc):
                     # for row in range(htrim.shape[0]):
                     for row in [0]:  # just print the top hit
                         hit = htrim["target name"][row]
-                        hit_msg = (hit + ": " + str(*benign_desc['Description'][benign_desc['ID'] == hit])
-                                   + f" (E-value: {htrim['E-value'][row]:.3g}")
+                        hit_msg = (
+                            hit
+                            + ": "
+                            + str(*benign_desc["Description"][benign_desc["ID"] == hit])
+                            + f" (E-value: {htrim['E-value'][row]:.3g}"
+                        )
                         descriptions.append(hit_msg + "\n")
                     annot_string = "\n".join(str(v) for v in descriptions)
                     logging.info(
@@ -123,7 +128,7 @@ def check_for_benign(query, coords, benign_desc):
     if not BlastNHandler.has_hits(blast):
         logging.info("\t...no Synbio sequence hits\n")
     else:
-        blastn = readblast(blast)  # synbio parts
+        blastn = read_blast(blast)  # synbio parts
         blastn = get_top_hits(blastn)
         for region in range(0, coords.shape[0]):  # for each regulated pathogen region
             htrim = blastn[
@@ -170,10 +175,10 @@ def check_for_benign(query, coords, benign_desc):
 
 
 def main():
-    '''
-    Alternative legacy entry point wrapper for calling check_benign as main, 
+    """
+    Alternative legacy entry point wrapper for calling check_benign as main,
     as isolated python script. No longer used in commec screen.
-    '''
+    """
     # Set up logging
     logging.basicConfig(
         level=logging.INFO,
@@ -198,9 +203,10 @@ def main():
         required=True,
         help="Benign HMM database folder (must contain benign_annotations.tsv)",
     )
-    parser.add_argument("-o","--out", dest="output_json",
-        required=True,help="output_json_filepath")
-    
+    parser.add_argument(
+        "-o", "--out", dest="output_json", required=True, help="output_json_filepath"
+    )
+
     args = parser.parse_args()
 
     if not os.path.exists(args.db + "/benign_annotations.tsv"):
@@ -226,6 +232,7 @@ def main():
     coords.reset_index(drop=True, inplace=True)
     rv = check_for_benign(args.sample_name, coords, benign_desc)
     sys.exit(rv)
+
 
 if __name__ == "__main__":
     main()

--- a/commec/screeners/check_benign.py
+++ b/commec/screeners/check_benign.py
@@ -16,7 +16,7 @@ import sys
 import pandas as pd
 
 from commec.tools.blastn import BlastNHandler # For has_hits.
-from commec.tools.blast_tools import tophits, readblast, trim_to_top_hits
+from commec.tools.blast_tools import get_top_hits, readblast, _trim_overlapping
 from commec.tools.hmmer import readhmmer
 from commec.tools.cmscan import readcmscan
 
@@ -124,8 +124,7 @@ def check_for_benign(query, coords, benign_desc):
         logging.info("\t...no Synbio sequence hits\n")
     else:
         blastn = readblast(blast)  # synbio parts
-        blastn = trim_to_top_hits(blastn)
-        blastn = tophits(blastn)
+        blastn = get_top_hits(blastn)
         for region in range(0, coords.shape[0]):  # for each regulated pathogen region
             htrim = blastn[
                 ~(

--- a/commec/screeners/check_benign.py
+++ b/commec/screeners/check_benign.py
@@ -16,7 +16,7 @@ import sys
 import pandas as pd
 
 from commec.tools.blastn import BlastNHandler # For has_hits.
-from commec.tools.blast_tools import tophits, readblast, trimblast
+from commec.tools.blast_tools import tophits, readblast, trim_to_top_hits
 from commec.tools.hmmer import readhmmer
 from commec.tools.cmscan import readcmscan
 
@@ -124,7 +124,7 @@ def check_for_benign(query, coords, benign_desc):
         logging.info("\t...no Synbio sequence hits\n")
     else:
         blastn = readblast(blast)  # synbio parts
-        blastn = trimblast(blastn)
+        blastn = trim_to_top_hits(blastn)
         blastn = tophits(blastn)
         for region in range(0, coords.shape[0]):  # for each regulated pathogen region
             htrim = blastn[

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -15,7 +15,7 @@ import re
 import sys
 import textwrap
 import pandas as pd
-from commec.tools.blast_tools import readblast, get_taxonomic_labels, get_top_hits
+from commec.tools.blast_tools import read_blast, get_taxonomic_labels, get_top_hits
 from commec.tools.blastn import BlastNHandler
 
 pd.set_option("display.max_colwidth", 10000)
@@ -96,7 +96,7 @@ def check_for_regulated_pathogens(input_file: str, input_database_dir: str, n_th
         logging.info("\t... Skipping regulated pathogens check, no hits in: %s\n", input_file)
         return 0
 
-    blast = readblast(input_file)
+    blast = read_blast(input_file)
     blast = get_taxonomic_labels(blast, reg_taxids, vax_taxids, input_database_dir + "/taxonomy/", n_threads)
     blast = blast[blast["species"] != ""]  # ignore submissions made above the species level
 

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -15,7 +15,7 @@ import re
 import sys
 import textwrap
 import pandas as pd
-from commec.tools.blast_tools import readblast, trimblast, taxdist, tophits
+from commec.tools.blast_tools import readblast, trim_to_top_hits, taxdist, tophits
 from commec.tools.blastn import BlastNHandler
 
 pd.set_option("display.max_colwidth", 10000)
@@ -100,8 +100,7 @@ def check_for_regulated_pathogens(input_file: str, input_database_dir: str, n_th
     blast = taxdist(blast, reg_taxids, vax_taxids, input_database_dir + "/taxonomy/", n_threads)
     blast = blast[blast["species"] != ""]  # ignore submissions made above the species level
 
-    # trim down to the top hit for each region, ignoring any top hits that are synthetic constructs
-    blast2 = trimblast(blast)
+    blast2 = trim_to_top_hits(blast)
     # label each base with the top matching hit, but include different taxids attributed to same hit
     blast2 = tophits(blast2)
 

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -15,7 +15,7 @@ import re
 import sys
 import textwrap
 import pandas as pd
-from commec.tools.blast_tools import readblast, _trim_to_top_hits, get_taxonomic_labels, get_top_hits
+from commec.tools.blast_tools import readblast, get_taxonomic_labels, get_top_hits
 from commec.tools.blastn import BlastNHandler
 
 pd.set_option("display.max_colwidth", 10000)
@@ -100,9 +100,8 @@ def check_for_regulated_pathogens(input_file: str, input_database_dir: str, n_th
     blast = get_taxonomic_labels(blast, reg_taxids, vax_taxids, input_database_dir + "/taxonomy/", n_threads)
     blast = blast[blast["species"] != ""]  # ignore submissions made above the species level
 
-    blast2 = trim_to_top_hits(blast)
     # label each base with the top matching hit, but include different taxids attributed to same hit
-    blast2 = tophits(blast2)
+    blast2 = get_top_hits(blast)
 
     reg_bac = 0
     reg_vir = 0

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -72,13 +72,13 @@ def check_for_regulated_pathogens(input_file: str, input_database_dir: str, n_th
     if not os.path.exists(benign_taxid_path):
         logging.error("\t...benign db file %s does not exist\n", benign_taxid_path)
         return 1
-    vax_taxids = pd.read_csv(benign_taxid_path, header=None, squeeze=True).astype(str).tolist()
+    vax_taxids = pd.read_csv(benign_taxid_path, header=None).squeeze().astype(str).tolist()
 
     biorisk_taxid_path = f"{input_database_dir}/biorisk_db/reg_taxids.txt"
     if not os.path.exists(biorisk_taxid_path):
         logging.error("\t...biorisk db file %s does not exist\n", biorisk_taxid_path)
         return 1
-    reg_taxids = pd.read_csv(biorisk_taxid_path, header=None, squeeze=True).astype(str).tolist()
+    reg_taxids = pd.read_csv(biorisk_taxid_path, header=None).squeeze().astype(str).tolist()
 
     # if there are already regulated regions written to file for this query, add to them
     hits1 = None

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -15,7 +15,7 @@ import re
 import sys
 import textwrap
 import pandas as pd
-from commec.tools.blast_tools import readblast, trim_to_top_hits, taxdist, tophits
+from commec.tools.blast_tools import readblast, _trim_to_top_hits, get_taxonomic_labels, get_top_hits
 from commec.tools.blastn import BlastNHandler
 
 pd.set_option("display.max_colwidth", 10000)
@@ -97,7 +97,7 @@ def check_for_regulated_pathogens(input_file: str, input_database_dir: str, n_th
         return 0
 
     blast = readblast(input_file)
-    blast = taxdist(blast, reg_taxids, vax_taxids, input_database_dir + "/taxonomy/", n_threads)
+    blast = get_taxonomic_labels(blast, reg_taxids, vax_taxids, input_database_dir + "/taxonomy/", n_threads)
     blast = blast[blast["species"] != ""]  # ignore submissions made above the species level
 
     blast2 = trim_to_top_hits(blast)

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -86,8 +86,8 @@ def test_get_lineages(mock_lineage, blast_df, lineage_df):
 def test_taxdist(mock_lineage, blast_df, lineage_df):
     mock_lineage.return_value = lineage_df
     # Fake values - should find 1 regulated hit after filtering
-    reg_taxids = [644357, 10760]
-    vax_taxids = [10760]
+    reg_taxids = ['644357', '10760']
+    vax_taxids = ['10760']
     reg_df = get_taxonomic_labels(
         blast_df, reg_taxids, vax_taxids, "/home/tessa/cm_databases/taxonomy/", 8
     )

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -4,7 +4,7 @@ import textwrap
 from unittest.mock import patch
 import numpy as np
 import pandas as pd
-from commec.tools.blast_tools import _split_by_tax_id, readblast, _get_lineages, get_taxonomic_labels
+from commec.tools.blast_tools import _split_by_tax_id, read_blast, _get_lineages, get_taxonomic_labels
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def blast_df():
         BT_01	SUBJECT	SUBJECT_ACC	32630	0.0	BITSCORE	99.999	300	275	300	500	1	100
         """
     )
-    return readblast(StringIO(blast_to_parse))
+    return read_blast(StringIO(blast_to_parse))
 
 
 @pytest.fixture

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -4,7 +4,7 @@ import textwrap
 from unittest.mock import patch
 import numpy as np
 import pandas as pd
-from commec.tools.blast_tools import _split_by_tax_id, readblast, _get_lineages
+from commec.tools.blast_tools import _split_by_tax_id, readblast, _get_lineages, taxdist
 
 
 @pytest.fixture
@@ -33,31 +33,33 @@ def lineage_df():
     """
     Dataframe subsetting columns from the results of pytaxonkit.lineage applied to blast_df
     """
-    return pd.DataFrame({
-        "TaxID": [2371, 644357, 10760, 110011001100, 32630],
-        "Code": [2371, 644357, 10760, -1, 32630],
-        "FullLineage": [
-            "cellular organisms;Bacteria;Pseudomonadota;Gammaproteobacteria;Lysobacterales;Lysobacteraceae;Xylella;Xylella fastidiosa",
-            "cellular organisms;Bacteria;Pseudomonadota;Gammaproteobacteria;Lysobacterales;Lysobacteraceae;Xylella;Xylella fastidiosa;Xylella fastidiosa subsp. multiplex",
-            "Viruses;Duplodnaviria;Heunggongvirae;Uroviricota;Caudoviricetes;Autographiviridae;Studiervirinae;Teseptimavirus;Teseptimavirus T7;Escherichia phage T7",
-            np.nan,
-            "other entries;other sequences;artificial sequences;synthetic construct",
-        ],
-        "FullLineageTaxIDs": [
-            "131567;2;1224;1236;135614;32033;2370;2371",
-            "131567;2;1224;1236;135614;32033;2370;2371;644357",
-            "10239;2731341;2731360;2731618;2731619;2731643;2731653;110456;1985738;10760",
-            np.nan,
-            "2787854;28384;81077;32630",
-        ],
-        "FullLineageRanks": [
-            "no rank;superkingdom;phylum;class;order;family;genus;species",
-            "no rank;superkingdom;phylum;class;order;family;genus;species;subspecies",
-            "superkingdom;clade;kingdom;phylum;class;family;subfamily;genus;species;no rank",
-            np.nan,
-            "no rank;no rank;no rank;species",
-        ],
-    })
+    return pd.DataFrame(
+        {
+            "TaxID": [2371, 644357, 10760, 110011001100, 32630],
+            "Code": [2371, 644357, 10760, -1, 32630],
+            "FullLineage": [
+                "cellular organisms;Bacteria;Pseudomonadota;Gammaproteobacteria;Lysobacterales;Lysobacteraceae;Xylella;Xylella fastidiosa",
+                "cellular organisms;Bacteria;Pseudomonadota;Gammaproteobacteria;Lysobacterales;Lysobacteraceae;Xylella;Xylella fastidiosa;Xylella fastidiosa subsp. multiplex",
+                "Viruses;Duplodnaviria;Heunggongvirae;Uroviricota;Caudoviricetes;Autographiviridae;Studiervirinae;Teseptimavirus;Teseptimavirus T7;Escherichia phage T7",
+                np.nan,
+                "other entries;other sequences;artificial sequences;synthetic construct",
+            ],
+            "FullLineageTaxIDs": [
+                "131567;2;1224;1236;135614;32033;2370;2371",
+                "131567;2;1224;1236;135614;32033;2370;2371;644357",
+                "10239;2731341;2731360;2731618;2731619;2731643;2731653;110456;1985738;10760",
+                np.nan,
+                "2787854;28384;81077;32630",
+            ],
+            "FullLineageRanks": [
+                "no rank;superkingdom;phylum;class;order;family;genus;species",
+                "no rank;superkingdom;phylum;class;order;family;genus;species;subspecies",
+                "superkingdom;clade;kingdom;phylum;class;family;subfamily;genus;species;no rank",
+                np.nan,
+                "no rank;no rank;no rank;species",
+            ],
+        }
+    )
 
 
 def test_split_by_tax_id(blast_df: pd.DataFrame):
@@ -68,11 +70,24 @@ def test_split_by_tax_id(blast_df: pd.DataFrame):
     assert set(split_blast["subject tax ids"]) == expected_tax_ids
 
 
-@patch('pytaxonkit.lineage')
+@patch("pytaxonkit.lineage")
 def test_get_lineages(mock_lineage, blast_df, lineage_df):
     mock_lineage.return_value = lineage_df
     blast_df = _split_by_tax_id(blast_df)
-    lin = _get_lineages(blast_df["subject tax ids"], "/home/tessa/cm_databases/taxonomy/", 8)
+    lin = _get_lineages(
+        blast_df["subject tax ids"], "/home/tessa/cm_databases/taxonomy/", 8
+    )
     # Expect the invalid taxid to be filtered out
     expected_tax_ids = {2371, 644357, 10760, 32630}
     assert set(lin["TaxID"]) == expected_tax_ids
+
+
+@patch("pytaxonkit.lineage")
+def test_taxdist(mock_lineage, blast_df, lineage_df):
+    mock_lineage.return_value = lineage_df
+    # Fake values - should find 1 regulated hit after filtering
+    reg_taxids = [644357, 10760]
+    vax_taxids = [10760]
+    test = taxdist(
+        blast_df, reg_taxids, vax_taxids, "/home/tessa/cm_databases/taxonomy/", 8
+    )

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -1,0 +1,32 @@
+from io import StringIO
+from pandas import DataFrame
+import pytest
+import textwrap
+from commec.tools.blast_tools import _split_by_tax_id, readblast
+
+@pytest.fixture
+def blast_df():
+    """
+    Return a dataframe containing 3 BLAST hits, 2 with multiple taxids, 1 of which is invalid and 1
+    of which is a synthetic taxid
+    """
+    blast_to_parse = textwrap.dedent(
+        """\
+        # BLASTX 2.15.0+
+        # Query: NC_TEST
+        # Database: /root/commec-dbs/mock
+        #query acc.	subject title	subject acc.	subject tax ids	evalue	bit score	% identity	query length	q. start	q. end	subject length	s. start	s. end
+        # 3 hits found
+        BT_01	SUBJECT	SUBJECT_ACC	2371;644357	0.0	BITSCORE	99.999	300	101	200	500	1	100
+        BT_01	SUBJECT	SUBJECT_ACC	10760;110011001100	0.0	BITSCORE	99.999	300	25	80	500	1	100
+        BT_01	SUBJECT	SUBJECT_ACC	32630	0.0	BITSCORE	99.999	300	275	300	500	1	100
+        """
+    )
+    return readblast(StringIO(blast_to_parse))
+
+def test_split_by_tax_id(blast_df: DataFrame):
+    assert len(blast_df) == 3
+    split_blast = _split_by_tax_id(blast_df)
+    assert len(split_blast) == 5
+    expected_tax_ids = {2371, 644357, 10760, 110011001100, 32630}
+    assert set(split_blast["subject tax ids"]) == expected_tax_ids

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -88,6 +88,15 @@ def test_taxdist(mock_lineage, blast_df, lineage_df):
     # Fake values - should find 1 regulated hit after filtering
     reg_taxids = [644357, 10760]
     vax_taxids = [10760]
-    test = taxdist(
+    reg_df = taxdist(
         blast_df, reg_taxids, vax_taxids, "/home/tessa/cm_databases/taxonomy/", 8
     )
+    # Expect the synthetic taxid to be filtered out
+    expected_tax_ids = {2371, 644357, 10760}
+    assert set(reg_df["subject tax ids"]) == expected_tax_ids
+
+    # Expect only taxid 644357 to be marked as "regulated"
+    assert not reg_df[reg_df["subject tax ids"] == 2371]["regulated"].iloc[0]
+    assWert reg_df[reg_df["subject tax ids"] == 644357]["regulated"].iloc[0]
+    assert not reg_df[reg_df["subject tax ids"] == 10760]["regulated"].iloc[0]
+W

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -97,6 +97,6 @@ def test_taxdist(mock_lineage, blast_df, lineage_df):
 
     # Expect only taxid 644357 to be marked as "regulated"
     assert not reg_df[reg_df["subject tax ids"] == 2371]["regulated"].iloc[0]
-    assWert reg_df[reg_df["subject tax ids"] == 644357]["regulated"].iloc[0]
+    assert reg_df[reg_df["subject tax ids"] == 644357]["regulated"].iloc[0]
     assert not reg_df[reg_df["subject tax ids"] == 10760]["regulated"].iloc[0]
-W
+

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -4,7 +4,7 @@ import textwrap
 from unittest.mock import patch
 import numpy as np
 import pandas as pd
-from commec.tools.blast_tools import _split_by_tax_id, readblast, _get_lineages, taxdist
+from commec.tools.blast_tools import _split_by_tax_id, readblast, _get_lineages, get_taxonomic_labels
 
 
 @pytest.fixture
@@ -88,7 +88,7 @@ def test_taxdist(mock_lineage, blast_df, lineage_df):
     # Fake values - should find 1 regulated hit after filtering
     reg_taxids = [644357, 10760]
     vax_taxids = [10760]
-    reg_df = taxdist(
+    reg_df = get_taxonomic_labels(
         blast_df, reg_taxids, vax_taxids, "/home/tessa/cm_databases/taxonomy/", 8
     )
     # Expect the synthetic taxid to be filtered out
@@ -96,7 +96,6 @@ def test_taxdist(mock_lineage, blast_df, lineage_df):
     assert set(reg_df["subject tax ids"]) == expected_tax_ids
 
     # Expect only taxid 644357 to be marked as "regulated"
-    assert not reg_df[reg_df["subject tax ids"] == 2371]["regulated"].iloc[0]
-    assert reg_df[reg_df["subject tax ids"] == 644357]["regulated"].iloc[0]
-    assert not reg_df[reg_df["subject tax ids"] == 10760]["regulated"].iloc[0]
-
+    assert reg_df[reg_df["subject tax ids"] == 2371]["regulated"].iloc[0] == False
+    assert reg_df[reg_df["subject tax ids"] == 644357]["regulated"].iloc[0] == True
+    assert reg_df[reg_df["subject tax ids"] == 10760]["regulated"].iloc[0] == False

--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -153,6 +153,7 @@ def taxdist(
         full_lineage.set_index("Rank", inplace=True)
         full_lineage_taxids = list(map(str, full_lineage["TaxID"]))
 
+        # If any organism in the lineage is synthetic, drop the row
         if any(
             taxid in [str(TAXID_SYNTHETIC_CONSTRUCTS), str(TAXID_VECTORS)]
             for taxid in full_lineage_taxids

--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -145,9 +145,9 @@ def taxdist(
         row_lin = lin[lin["TaxID"] == row[TAXIDS_COL]].iloc[0]
         full_lineage = pd.DataFrame(
             {
-                "Lineage": row_lin["FullLineage"].str.split(";"),
-                "TaxID": row_lin["FullLineageTaxIDs"].str.split(";"),
-                "Rank": row_lin["FullLineageRanks"].str.split(";"),
+                "Lineage": row_lin["FullLineage"].split(";"),
+                "TaxID": row_lin["FullLineageTaxIDs"].split(";"),
+                "Rank": row_lin["FullLineageRanks"].split(";"),
             }
         )
         full_lineage.set_index("Rank", inplace=True)
@@ -172,7 +172,7 @@ def taxdist(
         # Set additional taxonomic information
         for rank in ["superkingdom", "phylum", "genus", "species"]:
             if rank in full_lineage.index:
-                blast.at[index, rank] = full_lineage.loc[index, "Lineage"]
+                blast.at[index, rank] = full_lineage.loc[rank, "Lineage"]
             else:
                 blast.at[index, rank] = ""
 

--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -216,17 +216,17 @@ def readblast(fileh):
     return blast
 
 
-def trimblast(blast):
+def trim_to_top_hits(blast: pd.DataFrame):
     """
-    Trim BLAST results to the most interesting ones
+    Trim BLAST results down to the top hit for each region.
     """
     # set start to the lowest coordinate and end to the highest to avoid confusion
     blast = shift_hits_pos_strand(blast)
 
-    # rank hits by PID
     # if any multispecies hits contain regulated pathogens, put the regulated up top
     if "regulated" in blast:
         blast = blast.sort_values(by=["regulated"], ascending=False)
+    # rank hits by percent identity, then bit score
     blast = blast.sort_values(by=["% identity", "bit score"], ascending=False)
     blast = blast.reset_index(drop=True)
 
@@ -380,5 +380,5 @@ def tophits(blast2):
 def get_high_identity_matches(blast_output_file, threshold=90):
     """Read all hits with high sequence identity from a BLAST results file."""
     hits = readblast(blast_output_file)
-    hits = trimblast(hits)
+    hits = trim_to_top_hits(hits)
     return hits[hits["% identity"] >= threshold]

--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -3,13 +3,13 @@
 """
 Module for Blast related tools, a library for dealing with general blast file parsing tasks.
 Useful for reading any blast related outputs, for example from Blastx, Blastn, or diamond.
-(split_taxa, taxdist, readblast, trimblast, tophits)
+
 Also contains the abstract base class for blastX/N/Diamond database search handlers.
 """
 import os
 import logging
 import glob
-from typing import List
+from typing import List, Union, BinaryIO, TextIO
 import pytaxonkit
 import pandas as pd
 import numpy as np
@@ -186,11 +186,11 @@ def get_taxonomic_labels(
     return blast
 
 
-def readblast(fileh):
+def read_blast(blast_file: Union[str, os.PathLike, BinaryIO, TextIO]) -> pd.DataFrame:
     """
     Read in BLAST/DIAMOND files and pre-format the data frame with essential info
     """
-    blast = pd.read_csv(fileh, sep="\t", comment="#", header=None)
+    blast = pd.read_csv(blast_file, sep="\t", comment="#", header=None)
     columns = [
         "query acc.",
         "subject title",
@@ -363,6 +363,6 @@ def get_top_hits(blast: pd.DataFrame):
 
 def get_high_identity_matches(blast_output_file, threshold=90):
     """Read all hits with high sequence identity from a BLAST results file."""
-    hits = readblast(blast_output_file)
+    hits = read_blast(blast_output_file)
     hits = _trim_overlapping(hits)
     return hits[hits["% identity"] >= threshold]

--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -158,18 +158,18 @@ def get_taxonomic_labels(
 
         # If any organism in the lineage is synthetic, drop the row
         if any(
-            int(taxid) in [TAXID_SYNTHETIC_CONSTRUCTS, TAXID_VECTORS]
+            taxid in [str(TAXID_SYNTHETIC_CONSTRUCTS), str(TAXID_VECTORS)]
             for taxid in full_lineage_taxids
         ):
             rows_to_drop.append(index)
             continue
 
         # If any organism in the lineage is regulated, set this hit as regulated
-        if any(int(taxid) in regulated_taxids for taxid in full_lineage_taxids):
+        if any(taxid in regulated_taxids for taxid in full_lineage_taxids):
             blast.at[index, "regulated"] = True
 
         # Unless we're dealing with a known vaccine strain
-        if any(int(taxid) in vaccine_taxids for taxid in full_lineage_taxids):
+        if any(taxid in vaccine_taxids for taxid in full_lineage_taxids):
             blast.at[index, "regulated"] = False
 
         # Set additional taxonomic information


### PR DESCRIPTION
## Background

We were sometimes seeing this kind of error:
```
 >> STEP 2: Checking regulated pathogen proteins...
Problem with taxID 2855502 - check that your taxID and protein database are up to date
Traceback (most recent call last):
  File "/home/repository/commec/check_reg_path.py", line 153, in <module>
    main()
  File "/home/repository/commec/check_reg_path.py", line 57, in main
    blast = taxdist(blast, reg_ids, vax_ids, args.db + "/taxonomy/", args.threads)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/repository/commec/utils.py", line 118, in taxdist
    zip(
TypeError: 'float' object is not iterable
	 ERROR: command 'python /home/repository/commec/check_reg_path.py -i ./output/test.nr.blastx -d /home/cm-dbs/ -t 8' failed
```

after investigation, this turned out to be because `pytaxonkit.lineage` will return a column full of mostly `NaN`s if the taxonomy id has been deleted or cannot be found. Now we log a warning about that and drop the hits with outdated taxids.

## Changes

### Bug fixes
* Filter out deleted and invalid taxonomy ids
* Remove check for `pytaxonkit.lineage` results introduced in refactor (same issue caught by the filter above)

### Refactoring
* Add tests for some of the `blast_tools.py` methods
* Removed unused method in `blast_tools.py` and gave a few others more descriptive names