### PR TITLE
Yaml configuration input

### DIFF
--- a/commec-config.yaml
+++ b/commec-config.yaml
@@ -1,13 +1,12 @@
 base_paths:
-  default: /path/to/default/db/
-  test: /path/to/test/db/
+  default: /path/to/default/db/ # Overridden if database directory is passed in CLI to screen.
 
 # Database configurations
 databases:
   biorisk_hmm: 
     path: "{default}biorisk_db/biorisk.hmm"
   regulated_protein:
-    protein_search_tool: "blast"
+    protein_search_tool: "blastx" # Overrides CLI.
     blast:
       path: "{default}nr_blast/nr"
     diamond:
@@ -21,8 +20,3 @@ databases:
       path: "{default}benign_db/benign.fasta"
     cm:
       path: "{default}benign_db/benign.cm"
-
-# Override specific paths if needed
-overrides:
-  regulated_nt:
-    path: "{test}/nt_blast/nt"

--- a/commec-config.yaml
+++ b/commec-config.yaml
@@ -1,0 +1,27 @@
+base_paths:
+  default: /path/to/default/db/
+  test: /path/to/test/db/
+
+# Database configurations
+databases:
+  biorisk_hmm: 
+    path: "{default}biorisk_db/biorisk.hmm"
+  regulated_protein:
+    blast:
+      path: "{default}nr_blast/nr"
+    diamond:
+      path: "{default}nr_dmnd/nr.dmnd"
+  regulated_nt:
+    path: "{default}nt_blast/nt"
+  benign:
+    hmm:
+      path: "{default}benign_db/benign.hmm"
+    fasta:
+      path: "{default}benign_db/benign.fasta"
+    cm:
+      path: "{default}benign_db/benign.cm"
+
+# Override specific paths if needed
+overrides:
+  regulated_nt:
+    path: "{test}/nt_blast/nt"

--- a/commec-config.yaml
+++ b/commec-config.yaml
@@ -7,6 +7,7 @@ databases:
   biorisk_hmm: 
     path: "{default}biorisk_db/biorisk.hmm"
   regulated_protein:
+    protein_search_tool: "blast"
     blast:
       path: "{default}nr_blast/nr"
     diamond:

--- a/commec-config.yaml
+++ b/commec-config.yaml
@@ -1,5 +1,5 @@
 base_paths:
-  default: test_db_download/commec-dbs
+  default: commec-dbs/
 databases:
   benign:
     cm:

--- a/commec-config.yaml
+++ b/commec-config.yaml
@@ -1,22 +1,20 @@
 base_paths:
-  default: commec-dbs/ # Overridden if database directory is passed in CLI to screen.
-
-# Database configurations
+  default: test_db_download/commec-dbs
 databases:
-  biorisk_hmm: 
-    path: "{default}biorisk_db/biorisk.hmm"
-  regulated_protein:
-    protein_search_tool: "blastx" # Overrides CLI.
-    blast:
-      path: "{default}nr_blast/nr"
-    diamond:
-      path: "{default}nr_dmnd/nr.dmnd"
-  regulated_nt:
-    path: "{default}nt_blast/nt"
   benign:
-    hmm:
-      path: "{default}benign_db/benign.hmm"
-    fasta:
-      path: "{default}benign_db/benign.fasta"
     cm:
-      path: "{default}benign_db/benign.cm"
+      path: '{default}benign_db/benign.cm'
+    fasta:
+      path: '{default}benign_db/benign.fasta'
+    hmm:
+      path: '{default}benign_db/benign.hmm'
+  biorisk_hmm:
+    path: '{default}biorisk_db/biorisk.hmm'
+  regulated_nt:
+    path: '{default}nt_blast/nt'
+  regulated_protein:
+    blast:
+      path: '{default}nr_blast/nr'
+    diamond:
+      path: '{default}nr_dmnd/nr.dmnd'
+    protein_search_tool: blastx

--- a/commec-config.yaml
+++ b/commec-config.yaml
@@ -1,5 +1,5 @@
 base_paths:
-  default: /path/to/default/db/ # Overridden if database directory is passed in CLI to screen.
+  default: commec-dbs/ # Overridden if database directory is passed in CLI to screen.
 
 # Database configurations
 databases:

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -59,13 +59,13 @@ class ScreenIOParameters:
         # Query
         self.query: Query = Query(args.fasta_file)
 
-        # Storage of user input, used by screen_tools.
+        # Parse user input paths to local databases:
         self.db_dir = args.database_dir
         yaml_db_dir_override = self.db_dir if self.db_dir else None
 
         self.yaml_configuration = {}
         if os.path.exists(self.config.configuration_yaml_file):
-            self.get_configurations_from_yaml(self.config.configuration_yaml_file, self.db_dir)
+            self.get_configurations_from_yaml(self.config.configuration_yaml_file, yaml_db_dir_override)
         else:
             print("File not found: " + self.config.configuration_yaml_file)
             raise FileNotFoundError(
@@ -108,7 +108,11 @@ class ScreenIOParameters:
         self.query.setup(self.output_prefix)
         return True
 
-    def get_configurations_from_yaml(self, config_filepath : str, base_path_defaut_override : str = None):
+    def get_configurations_from_yaml(
+            self, 
+            config_filepath : str,
+            base_path_defaut_override : str = None
+        ):
         """ 
         Read the contents of a YAML file, to see 
         if it contains information to override configuration.
@@ -116,12 +120,15 @@ class ScreenIOParameters:
         """
         config = None
         try:
-            with open(config_filepath, 'r') as file:
+            with open(config_filepath, 'r', encoding="utf-8") as file:
                 config = yaml.safe_load(file)
         except ParserError as e:
             print(f"A configuration.yaml file was found ({config_filepath}) "
                    "but was invalid as a yaml file:\n",e)
             return {}
+        
+        if config["databases"]["regulated_protein"]["protein_search_tool"]:
+            self.config.protein_search_tool = config["databases"]["regulated_protein"]["protein_search_tool"]
 
         # Extract base paths for substitution
         base_paths = {}

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -109,18 +109,19 @@ class ScreenIOParameters:
         return True
 
     def get_configurations_from_yaml(
-            self, 
+            self,
             config_filepath : str,
             base_path_defaut_override : str = None
         ):
         """ 
         Read the contents of a YAML file, to see 
         if it contains information to override configuration.
-        TODO: Refactor this into json-IO, when opportunity arises.
+        TODO: Candidate for future yaml/json io refactor in future.
         """
         config = None
         try:
             with open(config_filepath, 'r', encoding="utf-8") as file:
+                print("Using configurations from " + config_filepath)
                 config = yaml.safe_load(file)
         except ParserError as e:
             print(f"A configuration.yaml file was found ({config_filepath}) "

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -61,14 +61,15 @@ class ScreenIOParameters:
 
         # Storage of user input, used by screen_tools.
         self.db_dir = args.database_dir
+        yaml_db_dir_override = self.db_dir if self.db_dir else None
 
         self.yaml_configuration = {}
         if os.path.exists(self.config.configuration_yaml_file):
-            self.get_configurations_from_yaml(self.config.configuration_yaml_file)
+            self.get_configurations_from_yaml(self.config.configuration_yaml_file, self.db_dir)
         else:
             print("File not found: " + self.config.configuration_yaml_file)
             raise FileNotFoundError(
-                f"No configuration yaml was found,{self.config.configuration_yaml_file}"
+                "No configuration yaml was found at " + self.config.configuration_yaml_file + " "
                 "if you are using a custom config file, check the path is correct"
             )
 
@@ -107,7 +108,7 @@ class ScreenIOParameters:
         self.query.setup(self.output_prefix)
         return True
 
-    def get_configurations_from_yaml(self, config_filepath : str):
+    def get_configurations_from_yaml(self, config_filepath : str, base_path_defaut_override : str = None):
         """ 
         Read the contents of a YAML file, to see 
         if it contains information to override configuration.
@@ -123,9 +124,11 @@ class ScreenIOParameters:
             return {}
 
         # Extract base paths for substitution
-        base_paths = []
+        base_paths = {}
         try:
             base_paths = config['base_paths']
+            if base_path_defaut_override:
+                base_paths["default"] = base_path_defaut_override
             # Function to recursively replace placeholders
             def recursive_format(d, base_paths):
                 if isinstance(d, dict):

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -121,7 +121,6 @@ class ScreenIOParameters:
         config = None
         try:
             with open(config_filepath, 'r', encoding="utf-8") as file:
-                print("Using configurations from " + config_filepath)
                 config = yaml.safe_load(file)
         except ParserError as e:
             print(f"A configuration.yaml file was found ({config_filepath}) "
@@ -148,9 +147,7 @@ class ScreenIOParameters:
             config = recursive_format(config, base_paths)
         except TypeError:
             pass
-        
-        #Debug print.
-        print(config)
+
         self.yaml_configuration = config
         return
 

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -9,14 +9,14 @@ import os
 import glob
 import argparse
 import logging
-import yaml
-from yaml.parser import ParserError
 from dataclasses import dataclass
 from typing import Optional
 import multiprocessing
 
-from commec.config.query import Query
+import yaml
+from yaml.parser import ParserError
 
+from commec.config.query import Query
 
 @dataclass
 class ScreenConfig:

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -48,7 +48,7 @@ class ScreenIOParameters:
             args.skip_nt_search,
             args.cleanup,
             args.diamond_jobs,
-            args.config_yaml,
+            args.config_yaml.strip()
         )
 
         # Outputs
@@ -65,6 +65,12 @@ class ScreenIOParameters:
         self.yaml_configuration = {}
         if os.path.exists(self.config.configuration_yaml_file):
             self.get_configurations_from_yaml(self.config.configuration_yaml_file)
+        else:
+            print("File not found: " + self.config.configuration_yaml_file)
+            raise FileNotFoundError(
+                f"No configuration yaml was found,{self.config.configuration_yaml_file}"
+                "if you are using a custom config file, check the path is correct"
+            )
 
         # Check whether a .screen output file already exists.
         if os.path.exists(self.output_screen_file):

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -126,7 +126,8 @@ class ScreenIOParameters:
             print(f"A configuration.yaml file was found ({config_filepath}) "
                    "but was invalid as a yaml file:\n",e)
             return {}
-        
+
+        # Override the protein search tool with the one set by the config file.
         if config["databases"]["regulated_protein"]["protein_search_tool"]:
             self.config.protein_search_tool = config["databases"]["regulated_protein"]["protein_search_tool"]
 

--- a/commec/config/screen_tools.py
+++ b/commec/config/screen_tools.py
@@ -6,7 +6,6 @@ Container for search handlers used throughout the Commec screen workflow.
 Sets and alters defaults based on input parameters.
 """
 
-import os
 import logging
 from typing import Union
 from commec.config.io_parameters import ScreenIOParameters
@@ -29,8 +28,10 @@ class ScreenTools:
         self.benign_blastn: BlastNHandler = None
         self.benign_cmscan: CmscanHandler = None
 
+        config_file = params.yaml_configuration
+
         self.biorisk_hmm = HmmerHandler(
-            os.path.join(params.db_dir, "biorisk_db/biorisk.hmm"),
+            config_file["databases"]["biorisk_hmm"]["path"],
             params.query.aa_path,
             f"{params.output_prefix}.biorisk.hmmscan",
             threads=params.config.threads,
@@ -39,14 +40,14 @@ class ScreenTools:
         if params.should_do_protein_screening:
             if params.config.protein_search_tool == "blastx":
                 self.regulated_protein = BlastXHandler(
-                    os.path.join(params.db_dir, "nr_blast/nr"),
+                    config_file["databases"]["regulated_protein"]["blast"]["path"],
                     input_file=params.query.nt_path,
                     out_file=f"{params.output_prefix}.nr.blastx",
                     threads=params.config.threads,
                 )
             elif params.config.protein_search_tool in ("nr.dmnd", "diamond"):
                 self.regulated_protein = DiamondHandler(
-                    os.path.join(params.db_dir, "nr_dmnd/nr.dmnd"),
+                    config_file["databases"]["regulated_protein"]["diamond"]["path"],
                     input_file=params.query.nt_path,
                     out_file=f"{params.output_prefix}.nr.dmnd",
                     threads=params.config.threads,
@@ -62,7 +63,7 @@ class ScreenTools:
 
         if params.should_do_nucleotide_screening:
             self.regulated_nt = BlastNHandler(
-                os.path.join(params.db_dir, "nt_blast/nt"),
+                config_file["databases"]["regulated_nt"]["path"],
                 input_file=f"{params.output_prefix}.noncoding.fasta",
                 out_file=f"{params.output_prefix}.nt.blastn",
                 threads=params.config.threads,
@@ -70,19 +71,19 @@ class ScreenTools:
 
         if params.should_do_benign_screening:
             self.benign_hmm = HmmerHandler(
-                os.path.join(params.db_dir, "benign_db/benign.hmm"),
+                config_file["databases"]["benign"]["hmm"]["path"],
                 input_file=params.query.aa_path,
                 out_file=f"{params.output_prefix}.benign.hmmscan",
                 threads=params.config.threads,
             )
             self.benign_blastn = BlastNHandler(
-                os.path.join(params.db_dir, "benign_db/benign.fasta"),
+                config_file["databases"]["benign"]["fasta"]["path"],
                 input_file=params.query.nt_path,
                 out_file=f"{params.output_prefix}.benign.blastn",
                 threads=params.config.threads,
             )
             self.benign_cmscan = CmscanHandler(
-                os.path.join(params.db_dir, "benign_db/benign.cm"),
+                config_file["databases"]["benign"]["cm"]["path"],
                 input_file=params.query.nt_path,
                 out_file=f"{params.output_prefix}.benign.cmscan",
                 threads=params.config.threads,

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -72,7 +72,7 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--databases",
         dest="database_dir",
         type=directory_arg,
-        required=True,
+        default = None,
         help="Path to directory containing reference databases (e.g. taxonomy, protein, HMM)",
     )
     parser.add_argument(

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy
   - pandas
   - pytaxonkit
+  - pyyaml
   # Runtime non-Python dependencies
   - bedtools
   - blast


### PR DESCRIPTION
## Background
* There was a need for better control on parsing database locations, as well as a system to easily add additional parameterisation into the commec screen program, that was not limited to CLI, thus removing the need for clunky shell/bash scripts.
* Commec now expects a mandatory default "commec-config.yaml" file as input, found in the repository.

### Dependencies:
* pyyaml is required now, and has been added to the environment.yml python dependencies.


### New features
* The location of the file can be specified as cli input to Commec Screen, however by default it will search for commec-config.yaml, which is also now part of the repository.
* Commec Setup CLI will update the base path of config file when databases are installed.
* Database location no longer a mandatory input, as it can be derived from config yaml, however yaml behaviour _can_ be overridden by forcing a database location in CLI when called Commec Screen.
* Yaml file will always override the blast/diamond protein search tool string - consider removing blast/diamond cli input for screen - kept to make this a non-breaking change for now.
* By parsing custom yaml files when calling Commec Screen, a user can easily automate the testing of different databases.
* Allows end user ease of use when installing commec dbs using setup CLI.

### Breaking changes 
nil, commec screen should still function identically using old calling methods, where the database directory is set via screen CLI.
