### PR TITLE
Add --force to Commec Screen CLI

### DIFF
--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -31,6 +31,7 @@ class ScreenConfig:
     do_cleanup: bool = False
     diamond_jobs: Optional[int] = None
     force: bool = False
+    resume: bool = False
 
 class ScreenIOParameters:
     """
@@ -46,6 +47,7 @@ class ScreenIOParameters:
             args.cleanup,
             args.diamond_jobs,
             args.force,
+            args.resume,
         )
 
         # Outputs
@@ -60,9 +62,15 @@ class ScreenIOParameters:
         self.db_dir = args.database_dir
 
         # Check whether a .screen output file already exists.
-        if os.path.exists(self.output_screen_file) and not self.config.force:
-            print(f"Screen output {self.output_screen_file} already exists. Aborting.")
+        # Note : The only operational difference between force and resume, is that resume is not passed into the search handlers.
+        if os.path.exists(self.output_screen_file) and not (self.config.force or self.config.resume):
+            print(f"Screen output {self.output_screen_file} already exists. \n"
+                  "Either use a different output location, or use --force, --resume to override. "
+                  "\nAborting Screen.")
             sys.exit(1)
+
+        if self.config.force and self.config.resume:
+            print("Warning: Using --force, overrides --resume behaviour.")
 
     def setup(self) -> bool:
         """

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) 2021-2024 International Biosecurity and Biosafety Initiative for Science
 """
-Defines the `ScreenIOParameters` class and associated dataclasses. 
-Objects responsible for parsing and interpreting user input for 
+Defines the `ScreenIOParameters` class and associated dataclasses.
+Objects responsible for parsing and interpreting user input for
 the screen workflow of commec.
 """
 import os
@@ -69,8 +69,6 @@ class ScreenIOParameters:
                   "\nAborting Screen.")
             sys.exit(1)
 
-        if self.config.force and self.config.resume:
-            print("Warning: Using --force, overrides --resume behaviour.")
 
     def setup(self) -> bool:
         """

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -6,6 +6,7 @@ Objects responsible for parsing and interpreting user input for
 the screen workflow of commec.
 """
 import os
+import sys
 import glob
 import argparse
 import logging
@@ -29,13 +30,12 @@ class ScreenConfig:
     skip_nt_search: bool = False
     do_cleanup: bool = False
     diamond_jobs: Optional[int] = None
-
+    force: bool = False
 
 class ScreenIOParameters:
     """
     Container for input settings constructed from arguments to `screen`.
     """
-
     def __init__(self, args: argparse.ArgumentParser):
         # Inputs
         self.config: ScreenConfig = ScreenConfig(
@@ -45,6 +45,7 @@ class ScreenIOParameters:
             args.skip_nt_search,
             args.cleanup,
             args.diamond_jobs,
+            args.force,
         )
 
         # Outputs
@@ -59,10 +60,9 @@ class ScreenIOParameters:
         self.db_dir = args.database_dir
 
         # Check whether a .screen output file already exists.
-        if os.path.exists(self.output_screen_file):
-            raise RuntimeError(
-                f"Screen output {self.output_screen_file} already exists. Aborting."
-            )
+        if os.path.exists(self.output_screen_file) and not self.config.force:
+            print(f"Screen output {self.output_screen_file} already exists. Aborting.")
+            sys.exit(1)
 
     def setup(self) -> bool:
         """

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -62,10 +62,9 @@ class ScreenIOParameters:
         self.db_dir = args.database_dir
 
         # Check whether a .screen output file already exists.
-        # Note : The only operational difference between force and resume, is that resume is not passed into the search handlers.
         if os.path.exists(self.output_screen_file) and not (self.config.force or self.config.resume):
             print(f"Screen output {self.output_screen_file} already exists. \n"
-                  "Either use a different output location, or use --force, --resume to override. "
+                  "Either use a different output location, or use --force or --resume to override. "
                   "\nAborting Screen.")
             sys.exit(1)
 

--- a/commec/config/screen_tools.py
+++ b/commec/config/screen_tools.py
@@ -34,6 +34,7 @@ class ScreenTools:
             params.query.aa_path,
             f"{params.output_prefix}.biorisk.hmmscan",
             threads=params.config.threads,
+            force=params.config.force,
         )
 
         if params.should_do_protein_screening:
@@ -43,6 +44,7 @@ class ScreenTools:
                     input_file=params.query.nt_path,
                     out_file=f"{params.output_prefix}.nr.blastx",
                     threads=params.config.threads,
+                    force=params.config.force,
                 )
             elif params.config.protein_search_tool in ("nr.dmnd", "diamond"):
                 self.regulated_protein = DiamondHandler(
@@ -50,6 +52,7 @@ class ScreenTools:
                     input_file=params.query.nt_path,
                     out_file=f"{params.output_prefix}.nr.dmnd",
                     threads=params.config.threads,
+                    force=params.config.force,
                 )
                 self.regulated_protein.jobs = params.config.diamond_jobs
                 if params.config.protein_search_tool == "nr.dmnd":
@@ -66,6 +69,7 @@ class ScreenTools:
                 input_file=f"{params.output_prefix}.noncoding.fasta",
                 out_file=f"{params.output_prefix}.nt.blastn",
                 threads=params.config.threads,
+                force=params.config.force,
             )
 
         if params.should_do_benign_screening:
@@ -74,16 +78,19 @@ class ScreenTools:
                 input_file=params.query.aa_path,
                 out_file=f"{params.output_prefix}.benign.hmmscan",
                 threads=params.config.threads,
+                force=params.config.force,
             )
             self.benign_blastn = BlastNHandler(
                 os.path.join(params.db_dir, "benign_db/benign.fasta"),
                 input_file=params.query.nt_path,
                 out_file=f"{params.output_prefix}.benign.blastn",
                 threads=params.config.threads,
+                force=params.config.force,
             )
             self.benign_cmscan = CmscanHandler(
                 os.path.join(params.db_dir, "benign_db/benign.cm"),
                 input_file=params.query.nt_path,
                 out_file=f"{params.output_prefix}.benign.cmscan",
                 threads=params.config.threads,
+                force=params.config.force,
             )

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -236,7 +236,7 @@ class Screen:
         Call hmmscan` and `check_biorisk.py` to add biorisk results to `screen_file`.
         """
         logging.debug("\t...running hmmscan")
-        self.database_tools.biorisk_hmm.search(self.params.config.force)
+        self.database_tools.biorisk_hmm.search()
         logging.debug("\t...checking hmmscan results")
         check_biorisk(
             self.database_tools.biorisk_hmm.out_file,
@@ -249,7 +249,7 @@ class Screen:
         pathogen protein screening results to `screen_file`.
         """
         logging.debug("\t...running %s", self.params.config.protein_search_tool)
-        self.database_tools.regulated_protein.search(self.params.config.force)
+        self.database_tools.regulated_protein.search()
         if not self.database_tools.regulated_protein.check_output():
             raise RuntimeError(
                 "ERROR: Expected protein search output not created: "
@@ -291,7 +291,7 @@ class Screen:
 
         # Only run new blastn search if there are no previous results
         if not self.database_tools.regulated_nt.check_output():
-            self.database_tools.regulated_nt.search(self.params.config.force)
+            self.database_tools.regulated_nt.search()
 
         if not self.database_tools.regulated_nt.check_output():
             raise RuntimeError(
@@ -317,11 +317,11 @@ class Screen:
             return
 
         logging.debug("\t...running benign hmmscan")
-        self.database_tools.benign_hmm.search(self.params.config.force)
+        self.database_tools.benign_hmm.search()
         logging.debug("\t...running benign blastn")
-        self.database_tools.benign_blastn.search(self.params.config.force)
+        self.database_tools.benign_blastn.search()
         logging.debug("\t...running benign cmscan")
-        self.database_tools.benign_cmscan.search(self.params.config.force)
+        self.database_tools.benign_cmscan.search()
 
         coords = pd.read_csv(sample_name + ".reg_path_coords.csv")
         benign_desc = pd.read_csv(

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -113,14 +113,15 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         action="store_true",
         help="Run in fast mode and skip homology search",
     )
-    parser.add_argument(
+    fr_group = parser.add_mutually_exclusive_group()
+    fr_group.add_argument(
         "-F",
         "--force",
         dest="force",
         action="store_true",
         help="Overwrite any pre-existing output for this Screen job.",
     )
-    parser.add_argument(
+    fr_group.add_argument(
         "-R",
         "--resume",
         dest="resume",

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -121,6 +121,13 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="Overwrite any pre-existing output for this Screen job.",
     )
     parser.add_argument(
+        "-R",
+        "--resume",
+        dest="resume",
+        action="store_true",
+        help="Re-use any pre-existing output for this Screen job.",
+    )
+    parser.add_argument(
         "-n",
         "--skip-nt",
         dest="skip_nt_search",

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -9,7 +9,7 @@ Screening involves (up to) four steps:
   2. Protein search:    protein homology search for best matches to regulated pathogens.
   3. Nucleotide search: nucleotide homology search for best matches to regulated pathogens.
   4. Benign scan:       three different scans (against conserved proteins, housekeeping RNAs, and
-                        synbio parts) to see if hits identified in homology search can be cleared. 
+                        synbio parts) to see if hits identified in homology search can be cleared.
 
 In "fast" mode, only the biorisk scan is run. By default, all four steps are run, but the nucleotide
 search is only run for regions that do not have any protein hits with a high sequence identity. The
@@ -23,22 +23,29 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -d DATABASE_DIR, --databases DATABASE_DIR
-                        Path to directory containing reference databases (e.g. taxonomy, protein,
-                        HMM)
+                        Path to directory containing reference databases
+
+Screen run logic:
+  -f, --fast            Run in fast mode and skip protein and nucleotide homology search
+  -p {blastx,diamond}, --protein-search-tool {blastx,diamond}
+                        Tool for protein homology search to identify regulated pathogens
+  -n, --skip-nt         Skip nucleotide search (regulated pathogens will only be identified based on
+                        protein hits)
+
+Parallelization:
+  -t THREADS, --threads THREADS
+                        Number of CPU threads to use. Passed to search tools.
+  -j DIAMOND_JOBS, --diamond-jobs DIAMOND_JOBS
+                        Diamond-only: number of runs to do in parallel
+
+Output file handling:
   -o OUTPUT_PREFIX, --output OUTPUT_PREFIX
                         Prefix for output files. Can be a string (interpreted as output basename) or
                         a directory (in which case the output file names will be determined from the
                         input FASTA)
-  -t THREADS, --threads THREADS
-                        Number of CPU threads to use. Passed to search tools.
-  -p {blastx,diamond}, --protein-search-tool {blastx,diamond}
-                        Tool for homology search to identify regulated pathogen proteins
-  -j DIAMOND_JOBS, --diamond-jobs DIAMOND_JOBS
-                        Diamond-only: number of runs to do in parallel
-  -f, --fast            Run in fast mode and skip homology search
-  -n, --skip-nt         Skip nucleotide search, even for regions where no protein hits were found
-  -c, --cleanup         Delete intermediate files
-
+  -c, --cleanup         Delete intermediate output files for this Screen run
+  -F, --force           Overwrite any pre-existing output for this Screen run
+  -R, --resume          Re-use any pre-existing output for this Screen run
 """
 import argparse
 import datetime
@@ -75,14 +82,31 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         required=True,
         help="Path to directory containing reference databases (e.g. taxonomy, protein, HMM)",
     )
-    parser.add_argument(
-        "-o",
-        "--output",
-        dest="output_prefix",
-        help="Prefix for output files. Can be a string (interpreted as output basename) or a"
-        + " directory (in which case the output file names will be determined from the input FASTA)",
+    screen_logic_group = parser.add_argument_group('Screen run logic')
+    screen_logic_group.add_argument(
+        "-f",
+        "--fast",
+        dest="fast_mode",
+        action="store_true",
+        help="Run in fast mode and skip protein and nucleotide homology search",
     )
-    parser.add_argument(
+    screen_logic_group.add_argument(
+        "-p",
+        "--protein-search-tool",
+        dest="protein_search_tool",
+        choices=["blastx", "diamond"],
+        default=default_config.protein_search_tool,
+        help="Tool for protein homology search to identify regulated pathogens",
+    )
+    screen_logic_group.add_argument(
+        "-n",
+        "--skip-nt",
+        dest="skip_nt_search",
+        action="store_true",
+        help="Skip nucleotide search (regulated pathogens will only be identified based on protein hits)",
+    )
+    parallel_group = parser.add_argument_group('Parallelization')
+    parallel_group.add_argument(
         "-t",
         "--threads",
         dest="threads",
@@ -90,15 +114,7 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         default=default_config.threads,
         help="Number of CPU threads to use. Passed to search tools.",
     )
-    parser.add_argument(
-        "-p",
-        "--protein-search-tool",
-        dest="protein_search_tool",
-        choices=["blastx", "diamond"],
-        default=default_config.protein_search_tool,
-        help="Tool for homology search to identify regulated pathogen proteins",
-    )
-    parser.add_argument(
+    parallel_group.add_argument(
         "-j",
         "--diamond-jobs",
         dest="diamond_jobs",
@@ -106,41 +122,35 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         default=default_config.diamond_jobs,
         help="Diamond-only: number of runs to do in parallel",
     )
-    parser.add_argument(
-        "-f",
-        "--fast",
-        dest="fast_mode",
-        action="store_true",
-        help="Run in fast mode and skip homology search",
+    output_handling_group = parser.add_argument_group('Output file handling')
+    output_exclusive_group = output_handling_group.add_mutually_exclusive_group()
+    output_handling_group.add_argument(
+        "-o",
+        "--output",
+        dest="output_prefix",
+        help="Prefix for output files. Can be a string (interpreted as output basename) or a"
+        + " directory (in which case the output file names will be determined from the input FASTA)",
     )
-    fr_group = parser.add_mutually_exclusive_group()
-    fr_group.add_argument(
-        "-F",
-        "--force",
-        dest="force",
-        action="store_true",
-        help="Overwrite any pre-existing output for this Screen job.",
-    )
-    fr_group.add_argument(
-        "-R",
-        "--resume",
-        dest="resume",
-        action="store_true",
-        help="Re-use any pre-existing output for this Screen job.",
-    )
-    parser.add_argument(
-        "-n",
-        "--skip-nt",
-        dest="skip_nt_search",
-        action="store_true",
-        help="Skip nucleotide search, even for regions where no protein hits were found",
-    )
-    parser.add_argument(
+    output_handling_group.add_argument(
         "-c",
         "--cleanup",
         dest="cleanup",
         action="store_true",
-        help="Delete intermediate files",
+        help="Delete intermediate output files for this Screen run",
+    )
+    output_exclusive_group.add_argument(
+        "-F",
+        "--force",
+        dest="force",
+        action="store_true",
+        help="Overwrite any pre-existing output for this Screen run (cannot be used with --resume)",
+    )
+    output_exclusive_group.add_argument(
+        "-R",
+        "--resume",
+        dest="resume",
+        action="store_true",
+        help="Re-use any pre-existing output for this Screen run (cannot be used with --force)",
     )
     return parser
 

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -114,6 +114,13 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="Run in fast mode and skip homology search",
     )
     parser.add_argument(
+        "-F",
+        "--force",
+        dest="force",
+        action="store_true",
+        help="Overwrite any pre-existing output for this Screen job.",
+    )
+    parser.add_argument(
         "-n",
         "--skip-nt",
         dest="skip_nt_search",
@@ -229,7 +236,7 @@ class Screen:
         Call hmmscan` and `check_biorisk.py` to add biorisk results to `screen_file`.
         """
         logging.debug("\t...running hmmscan")
-        self.database_tools.biorisk_hmm.search()
+        self.database_tools.biorisk_hmm.search(self.params.config.force)
         logging.debug("\t...checking hmmscan results")
         check_biorisk(
             self.database_tools.biorisk_hmm.out_file,
@@ -242,7 +249,7 @@ class Screen:
         pathogen protein screening results to `screen_file`.
         """
         logging.debug("\t...running %s", self.params.config.protein_search_tool)
-        self.database_tools.regulated_protein.search()
+        self.database_tools.regulated_protein.search(self.params.config.force)
         if not self.database_tools.regulated_protein.check_output():
             raise RuntimeError(
                 "ERROR: Expected protein search output not created: "
@@ -284,7 +291,7 @@ class Screen:
 
         # Only run new blastn search if there are no previous results
         if not self.database_tools.regulated_nt.check_output():
-            self.database_tools.regulated_nt.search()
+            self.database_tools.regulated_nt.search(self.params.config.force)
 
         if not self.database_tools.regulated_nt.check_output():
             raise RuntimeError(
@@ -310,11 +317,11 @@ class Screen:
             return
 
         logging.debug("\t...running benign hmmscan")
-        self.database_tools.benign_hmm.search()
+        self.database_tools.benign_hmm.search(self.params.config.force)
         logging.debug("\t...running benign blastn")
-        self.database_tools.benign_blastn.search()
+        self.database_tools.benign_blastn.search(self.params.config.force)
         logging.debug("\t...running benign cmscan")
-        self.database_tools.benign_cmscan.search()
+        self.database_tools.benign_cmscan.search(self.params.config.force)
 
         coords = pd.read_csv(sample_name + ".reg_path_coords.csv")
         benign_desc = pd.read_csv(

--- a/commec/tests/test_dbs.py
+++ b/commec/tests/test_dbs.py
@@ -41,7 +41,8 @@ def test_database_can_run(input_db):
     output_file = "db.out"
 
     new_db = input_db[0](db_file, INPUT_QUERY, output_file)
-    new_db.search()
+    always_run : bool = True
+    new_db.search(always_run)
     assert new_db.check_output()
 
     version: str = new_db.get_version_information()

--- a/commec/tests/test_dbs.py
+++ b/commec/tests/test_dbs.py
@@ -40,9 +40,8 @@ def test_database_can_run(input_db):
 
     output_file = "db.out"
 
-    new_db = input_db[0](db_file, INPUT_QUERY, output_file)
-    always_run : bool = True
-    new_db.search(always_run)
+    new_db = input_db[0](db_file, INPUT_QUERY, output_file, force=True)
+    new_db.search()
     assert new_db.check_output()
 
     version: str = new_db.get_version_information()

--- a/commec/tools/blastn.py
+++ b/commec/tools/blastn.py
@@ -46,7 +46,7 @@ class BlastNHandler(BlastHandler):
         }
         self.blastcall = "blastn"
 
-    def search(self):
+    def _search(self):
         command = [
             self.blastcall,
             "-query",

--- a/commec/tools/blastn.py
+++ b/commec/tools/blastn.py
@@ -18,9 +18,9 @@ class BlastNHandler(BlastHandler):
     """
 
     def __init__(
-        self, database_file: str, input_file: str, out_file: str, threads: int = 8
+        self, database_file: str, input_file: str, out_file: str, **kwargs,
     ):
-        super().__init__(database_file, input_file, out_file, threads)
+        super().__init__(database_file, input_file, out_file, kwargs=kwargs)
         # We fill this with defaults, however they can always be overridden before screening.
         self.arguments_dictionary = {
             "-outfmt": [

--- a/commec/tools/blastn.py
+++ b/commec/tools/blastn.py
@@ -20,7 +20,7 @@ class BlastNHandler(BlastHandler):
     def __init__(
         self, database_file: str, input_file: str, out_file: str, **kwargs,
     ):
-        super().__init__(database_file, input_file, out_file, kwargs=kwargs)
+        super().__init__(database_file, input_file, out_file, **kwargs)
         # We fill this with defaults, however they can always be overridden before screening.
         self.arguments_dictionary = {
             "-outfmt": [

--- a/commec/tools/blastx.py
+++ b/commec/tools/blastx.py
@@ -20,7 +20,7 @@ class BlastXHandler(BlastHandler):
     def __init__(
         self, database_file: str, input_file: str, out_file: str, **kwargs,
     ):
-        super().__init__(database_file, input_file, out_file, kwargs=kwargs)
+        super().__init__(database_file, input_file, out_file, **kwargs)
         # We fill this with defaults, however they can always be overridden before screening.
         self.arguments_dictionary = {
             "-num_threads": self.threads,

--- a/commec/tools/blastx.py
+++ b/commec/tools/blastx.py
@@ -53,7 +53,7 @@ class BlastXHandler(BlastHandler):
         }
         self.blastcall = "blastx"
 
-    def search(self):
+    def _search(self):
         command = [
             self.blastcall,
             "-db",

--- a/commec/tools/blastx.py
+++ b/commec/tools/blastx.py
@@ -18,9 +18,9 @@ class BlastXHandler(BlastHandler):
     """
 
     def __init__(
-        self, database_file: str, input_file: str, out_file: str, threads: int = 8
+        self, database_file: str, input_file: str, out_file: str, **kwargs,
     ):
-        super().__init__(database_file, input_file, out_file, threads)
+        super().__init__(database_file, input_file, out_file, kwargs=kwargs)
         # We fill this with defaults, however they can always be overridden before screening.
         self.arguments_dictionary = {
             "-num_threads": self.threads,

--- a/commec/tools/cmscan.py
+++ b/commec/tools/cmscan.py
@@ -15,7 +15,7 @@ from commec.tools.search_handler import SearchHandler, SearchToolVersion
 class CmscanHandler(SearchHandler):
     """A Database handler specifically for use with Hmmer files for commec screening."""
 
-    def search(self):
+    def _search(self):
         command = [
             "cmscan",
             "--cpu",
@@ -29,6 +29,7 @@ class CmscanHandler(SearchHandler):
 
     def get_version_information(self) -> SearchToolVersion:
         try:
+            database_info = None
             with open(self.db_file, "r", encoding="utf-8") as file:
                 for line in file:
                     if line.startswith("INFERNAL1/a"):

--- a/commec/tools/diamond.py
+++ b/commec/tools/diamond.py
@@ -128,7 +128,7 @@ class DiamondHandler(BlastHandler):
 
         return n_concurrent_runs, n_threads_per_run
 
-    def search(self):
+    def _search(self):
         """
         Search the DIAMOND-formatted nr protein database for matches to the query file.
         """

--- a/commec/tools/diamond.py
+++ b/commec/tools/diamond.py
@@ -26,7 +26,7 @@ class DiamondHandler(BlastHandler):
     """
 
     def __init__(self, database_file: str, input_file: str, out_file: str, **kwargs):
-        super().__init__(database_file, input_file, out_file, kwargs=kwargs)
+        super().__init__(database_file, input_file, out_file, **kwargs)
         self.frameshift: int = 15
         self.do_range_culling = True
         self.jobs: Optional[int] = None

--- a/commec/tools/diamond.py
+++ b/commec/tools/diamond.py
@@ -25,8 +25,8 @@ class DiamondHandler(BlastHandler):
     Concatenates all diamond outputs into a single output file.
     """
 
-    def __init__(self, database_file: str, input_file: str, out_file: str, threads: int = 1):
-        super().__init__(database_file, input_file, out_file, threads)
+    def __init__(self, database_file: str, input_file: str, out_file: str, **kwargs):
+        super().__init__(database_file, input_file, out_file, kwargs=kwargs)
         self.frameshift: int = 15
         self.do_range_culling = True
         self.jobs: Optional[int] = None

--- a/commec/tools/hmmer.py
+++ b/commec/tools/hmmer.py
@@ -15,7 +15,7 @@ from commec.tools.search_handler import SearchHandler, SearchToolVersion
 class HmmerHandler(SearchHandler):
     """A Database handler specifically for use with Hmmer files for commec screening."""
 
-    def search(self):
+    def _search(self):
         command = [
             "hmmscan",
             "--cpu",

--- a/commec/tools/search_handler.py
+++ b/commec/tools/search_handler.py
@@ -55,8 +55,21 @@ class SearchHandler(ABC):
         """Temporary log file used for this search. Based on outfile name."""
         return f"{self.out_file}.log.tmp"
 
+    def search(self, force: bool):
+        """
+        Wrapper for _search, to ensure that it is only called if 
+         - The output doesn't already exist,
+         - If force is enabled.
+        """
+        if not force and self.check_output():
+            logging.info("%s expected output data already exists, "
+                         "will use existing data found in:\n%s",
+                         self.__class__.__name__, self.out_file)
+            return
+        self._search()
+
     @abstractmethod
-    def search(self):
+    def _search(self):
         """
         Use a tool to search the input query against a database.
         Should be implemented by all subclasses to perform the actual search against the database.

--- a/commec/tools/search_handler.py
+++ b/commec/tools/search_handler.py
@@ -33,13 +33,37 @@ class SearchHandler(ABC):
         database_file: str | os.PathLike,
         input_file: str | os.PathLike,
         out_file: str | os.PathLike,
-        threads: int = 1,
+        **kwargs,
     ):
+        """
+        Initialise a Search Handler.
+
+        Parameters
+        ----------
+        database_file : str | os.PathLike
+            Path to the database file.
+        input_file : str | os.PathLike
+            Path to the input file to be processed.
+        out_file : str | os.PathLike
+            Path where the output will be saved.
+
+        Keyword Arguments
+        -----------------
+        threads : int, optional
+            Number of threads to use for processing. Default is 1.
+        force : bool, optional
+            Whether to force overwrite existing files. Default is False.
+
+        Notes
+        -----
+        - `database_file`, `input_file`, and `out_file` are validated on instantiation.
+        """
+
         self.db_file = os.path.abspath(database_file)
         self.input_file = os.path.abspath(input_file)
         self.out_file = os.path.abspath(out_file)
-        self.threads = threads
-
+        self.threads = kwargs.get('threads', 1)
+        self.force = kwargs.get('force', False)
         self.arguments_dictionary = {}
 
         self._validate_db()
@@ -55,13 +79,13 @@ class SearchHandler(ABC):
         """Temporary log file used for this search. Based on outfile name."""
         return f"{self.out_file}.log.tmp"
 
-    def search(self, force: bool):
+    def search(self):
         """
         Wrapper for _search, to ensure that it is only called if 
          - The output doesn't already exist,
          - If force is enabled.
         """
-        if not force and self.check_output():
+        if not self.force and self.check_output():
             logging.info("%s expected output data already exists, "
                          "will use existing data found in:\n%s",
                          self.__class__.__name__, self.out_file)


### PR DESCRIPTION
Added --force, -F, feature to the Commec Screen CLI.

## Background

When re-running Commec Screen, pre-existing outputs caused RunTimeErrors for the pre-existing .screen file. Furthermore, there was little to no control on re-running some database searches whilst skipping others.

## Changes

* Added --force or -F to Commec Screen CLI.
* Databases try to re-use existing output data by default (only applies if .screen file doesn't exist)
* Some minor logging to inform the user that the database outputs are being re-used.
* Search Handler base class now has the private _screen, and screen wrapper, to facilitate the logic of passing force bool.
* io_parameters.py no longer raises an exception when .screen is present unexpectedly, and instead cleaning quits.

### New features
With the addition of a Force parameter, databases can by default check if their outputs already exist, and use them instead. The .screen file can also be over-written with --force. This allows the following highlight example use-cases:
* Rerun Screen entirely - use --force.
* Rerun Screen, whilst not re-running any particular database - delete .screen output, keep any database output.
* Accidentally overwrite any outputs from a previous run? - not possible (without --force) due to pre-existing .screen file check. System exits gracefully.

### Refactoring
* Derived search_handlers now override _screen() private function, rather than screen(force : bool).