### PR TITLE
Bugfix for Benign Search

### DIFF
--- a/commec/screen.py
+++ b/commec/screen.py
@@ -322,6 +322,10 @@ class Screen:
             sep="\t",
         )
 
+        if coords.shape[0] == 0:
+                logging.info("\t...no regulated regions to clear\n")
+                return
+
         logging.debug("\t...checking benign scan results")
 
         # Note currently check_for_benign hard codes .benign.hmmscan,


### PR DESCRIPTION
benign search was running when the reg_path_coords.csv existing, but was empty, leading to some erroneous outputs to the screen file.

## Changes
Added the check for the shape of the imported csv, checking if it is 0, and returning early if it is. As was previous behaviour pre-refactor.