### PR TITLE
Critical Conda Recipe Fix

### DIFF
--- a/commec/setup.py
+++ b/commec/setup.py
@@ -175,7 +175,7 @@ class CliSetup:
         # Handily, all sorts of special characters are identified with a %XX, within posix, and are replaced
         # by similar characters during mkdir, whilst technically legal, lets recommend against cursed dir names.
         if '%' in path.as_posix():
-            print("Please avoid using special characters (\"|\}{\":?><*&\" etc) in filepath names.")
+            print("Please avoid using special characters (\"|}{\":?><*&\" etc) in filepath names.")
             return False
     
         # If the path doesn't exist, the best way to know if user input is valid, is to try make it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commec"
-version = '0.1.0'
+version = '0.2.0'
 # This is not a pure python project; dependencies are managed through environment.yml
 authors = [
   { name = "Nicole Wheeler" },
@@ -35,4 +35,4 @@ Repository = "https://github.com/ibbis-screening/common-mechanism.git"
 "commec" = "commec.cli:main"
 
 [tool.setuptools]
-packages = { find = { "include" = ["commec"] } }
+packages = { find = { "include" = ["commec", "commec.*"] } }


### PR DESCRIPTION
Conda recipe build process and testing will not work without additional modules being made explicit in the pyproject.toml, to include commec.utils etc as modules, due to the refactor the code into modules.

Adding commec.* with the wildcard neatly fixes this issue.

Also removed erroneous \ from print statement in setup.py as a small additional bugfix.

## Changes

Added commec.* to the list of includes for tool.setupstools packages dictionary.
Removed \, escape sequence present in string in setup.pys, to remove a print error."

### Follow-up
* Just need this to launch the conda recipe for 0.2.0. We need these changes inside that tagged release.
