### PR TITLE
Collapse Taxonomic hits based on hit name, rather than the hit accession string.

### DIFF
--- a/commec/screen.py
+++ b/commec/screen.py
@@ -509,7 +509,7 @@ class Screen:
 
         if exit_status != 0:
             raise RuntimeError(
-                f"Output of protein taxonomy search could not be processed: {self.database_tools.regulated_protein.out_file} {exit_status}"
+                f"Output of protein taxonomy search could not be processed: {self.database_tools.regulated_protein.out_file}"
             )
 
     def screen_nucleotides(self):

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -509,7 +509,7 @@ class Screen:
 
         if exit_status != 0:
             raise RuntimeError(
-                f"Output of protein taxonomy search could not be processed: {self.database_tools.regulated_protein.out_file}"
+                f"Output of protein taxonomy search could not be processed: {self.database_tools.regulated_protein.out_file} {exit_status}"
             )
 
     def screen_nucleotides(self):

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -173,6 +173,7 @@ def parse_taxonomy_hits(
         for hit in regulated_hits:
             logger.debug("\t\tProcessing Hit: %s", hit)
             regulated_hit_data : pd.DataFrame = regulated_only_data[regulated_only_data["subject acc."] == hit]
+            hit_name = regulated_hit_data['subject title'].values[0]
             logger.debug("%s Regulated Hit Data: shape: %s preview:\n%s",
                          step, regulated_hit_data.shape, regulated_hit_data.head())
 
@@ -298,7 +299,7 @@ def parse_taxonomy_hits(
                     screen_status,
                     step
                 ),
-                hit,
+                hit_name,
                 hit_description,
                 match_ranges,
                 {"domain" : [domain],"regulated_taxonomy":[regulation_dict]},

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -2,8 +2,8 @@
   "commec_info": {
     "commec_version": "1.0.2",
     "json_output_version": "0.3",
-    "time_taken": "00:00:05",
-    "date_run": "2025-10-03 01:17:02",
+    "time_taken": "00:00:02",
+    "date_run": "2025-12-03 16:57:20",
     "search_tool_info": {
       "biorisk_search_info": {
         "tool_info": "# HMMER 3.4 (Aug 2023); http://hmmer.org/",
@@ -32,7 +32,7 @@
     }
   },
   "query_info": {
-    "file": "/tmp/pytest-of-root/pytest-54/test_functional_screen0/functional.fasta",
+    "file": "/tmp/pytest-of-root/pytest-10/test_functional_screen0/functional.fasta",
     "number_of_queries": 1,
     "total_query_length": 600
   },
@@ -49,12 +49,12 @@
         "rationale": "Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
       },
       "hits": {
-        "NT_HIT_MIXED": {
+        "Main": {
           "recommendation": {
             "status": "Pass",
             "from_step": "Nucleotide Taxonomy Search"
           },
-          "name": "NT_HIT_MIXED",
+          "name": "Main",
           "description": "Mix of 1 regulated Viruses and 1 non-regulated Viruses",
           "ranges": [
             {
@@ -102,13 +102,13 @@
             ]
           }
         },
-        "NT_HIT_FLAG3": {
+        "SUBJECT_3": {
           "recommendation": {
             "status": "Flag",
             "from_step": "Nucleotide Taxonomy Search"
           },
-          "name": "NT_HIT_FLAG3",
-          "description": "Regulated Viruses - SUBJECT",
+          "name": "SUBJECT_3",
+          "description": "Regulated Viruses - SUBJECT_3",
           "ranges": [
             {
               "e_value": 0.15,
@@ -137,7 +137,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Viruses",
                     "target_hit": "NT_HIT_FLAG2",
-                    "target_description": "SUBJECT"
+                    "target_description": "SUBJECT_2"
                   },
                   {
                     "evalue": 0.15,
@@ -146,7 +146,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Viruses",
                     "target_hit": "NT_HIT_FLAG3",
-                    "target_description": "SUBJECT"
+                    "target_description": "SUBJECT_3"
                   }
                 ],
                 "non_regulated_taxa": []
@@ -154,13 +154,13 @@
             ]
           }
         },
-        "NT_HIT_FLAG2": {
+        "SUBJECT_2": {
           "recommendation": {
             "status": "Flag (Cleared)",
             "from_step": "Nucleotide Taxonomy Search"
           },
-          "name": "NT_HIT_FLAG2",
-          "description": "Regulated Viruses - SUBJECT",
+          "name": "SUBJECT_2",
+          "description": "Regulated Viruses - SUBJECT_2",
           "ranges": [
             {
               "e_value": 0.14,
@@ -189,7 +189,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Viruses",
                     "target_hit": "NT_HIT_FLAG2",
-                    "target_description": "SUBJECT"
+                    "target_description": "SUBJECT_2"
                   },
                   {
                     "evalue": 0.15,
@@ -198,7 +198,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Viruses",
                     "target_hit": "NT_HIT_FLAG3",
-                    "target_description": "SUBJECT"
+                    "target_description": "SUBJECT_3"
                   }
                 ],
                 "non_regulated_taxa": []
@@ -206,13 +206,13 @@
             ]
           }
         },
-        "NT_HIT_FLAG1": {
+        "SUBJECT_1": {
           "recommendation": {
             "status": "Flag (Cleared)",
             "from_step": "Nucleotide Taxonomy Search"
           },
-          "name": "NT_HIT_FLAG1",
-          "description": "Regulated Viruses - SUBJECT",
+          "name": "SUBJECT_1",
+          "description": "Regulated Viruses - SUBJECT_1",
           "ranges": [
             {
               "e_value": 0.13,
@@ -241,7 +241,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Viruses",
                     "target_hit": "NT_HIT_FLAG1",
-                    "target_description": "SUBJECT"
+                    "target_description": "SUBJECT_1"
                   }
                 ],
                 "non_regulated_taxa": []
@@ -249,12 +249,12 @@
             ]
           }
         },
-        "NR_HIT_MIXED1": {
+        "ShouldMixedReg1": {
           "recommendation": {
             "status": "Pass",
             "from_step": "Protein Taxonomy Search"
           },
-          "name": "NR_HIT_MIXED1",
+          "name": "ShouldMixedReg1",
           "description": "Mix of 1 regulated Viruses and 2 non-regulated Viruses",
           "ranges": [
             {
@@ -284,7 +284,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Viruses",
                     "target_hit": "NR_HIT_MIXED1",
-                    "target_description": "ShouldMixedReg"
+                    "target_description": "ShouldMixedReg1"
                   }
                 ],
                 "non_regulated_taxa": [
@@ -295,7 +295,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Bacteria",
                     "target_hit": "NR_HIT_MIXED2",
-                    "target_description": "ShouldMixednonReg"
+                    "target_description": "ShouldMixednonReg2"
                   },
                   {
                     "evalue": 0.12,
@@ -304,19 +304,19 @@
                     "genus": "unclassified",
                     "superkingdom": "Bacteria",
                     "target_hit": "NR_HIT_MIXED3",
-                    "target_description": "ShouldMixedNonReg"
+                    "target_description": "ShouldMixedNonReg3"
                   }
                 ]
               }
             ]
           }
         },
-        "NR_HIT_FLAG4": {
+        "ShouldClear": {
           "recommendation": {
             "status": "Flag (Cleared)",
             "from_step": "Protein Taxonomy Search"
           },
-          "name": "NR_HIT_FLAG4",
+          "name": "ShouldClear",
           "description": "Regulated Viruses - ShouldClear",
           "ranges": [
             {
@@ -354,13 +354,13 @@
             ]
           }
         },
-        "NR_HIT_FLAG3": {
+        "NR_HIT2_ShouldntClear": {
           "recommendation": {
             "status": "Flag",
             "from_step": "Protein Taxonomy Search"
           },
-          "name": "NR_HIT_FLAG3",
-          "description": "Regulated Viruses - ShouldntClear",
+          "name": "NR_HIT2_ShouldntClear",
+          "description": "Regulated Viruses - NR_HIT2_ShouldntClear",
           "ranges": [
             {
               "e_value": 0.08,
@@ -397,12 +397,12 @@
             ]
           }
         },
-        "NR_HIT_FLAG2": {
+        "ShouldClearBySynBio": {
           "recommendation": {
             "status": "Flag (Cleared)",
             "from_step": "Protein Taxonomy Search"
           },
-          "name": "NR_HIT_FLAG2",
+          "name": "ShouldClearBySynBio",
           "description": "Regulated Viruses - ShouldClearBySynBio",
           "ranges": [
             {
@@ -440,13 +440,13 @@
             ]
           }
         },
-        "NR_HIT_FLAG1": {
+        "NR_HIT_ShouldntClear": {
           "recommendation": {
             "status": "Flag",
             "from_step": "Protein Taxonomy Search"
           },
-          "name": "NR_HIT_FLAG1",
-          "description": "Regulated Viruses - ShouldntClear",
+          "name": "NR_HIT_ShouldntClear",
+          "description": "Regulated Viruses - NR_HIT_ShouldntClear",
           "ranges": [
             {
               "e_value": 0.06,
@@ -475,7 +475,7 @@
                     "genus": "unclassified",
                     "superkingdom": "Viruses",
                     "target_hit": "NR_HIT_FLAG1",
-                    "target_description": "ShouldntClear"
+                    "target_description": "NR_HIT_ShouldntClear"
                   }
                 ],
                 "non_regulated_taxa": []
@@ -483,12 +483,12 @@
             ]
           }
         },
-        "Toxin1": {
+        "Toxin1a": {
           "recommendation": {
             "status": "Flag",
             "from_step": "Biorisk Search"
           },
-          "name": "Toxin1",
+          "name": "Toxin1a",
           "description": "LargeAreaFlag",
           "ranges": [
             {
@@ -497,7 +497,25 @@
               "match_end": 29,
               "query_start": 4,
               "query_end": 93
-            },
+            }
+          ],
+          "annotations": {
+            "domain": [
+              "not assigned"
+            ],
+            "regulated": [
+              "Regulated Gene"
+            ]
+          }
+        },
+        "Toxin1b": {
+          "recommendation": {
+            "status": "Flag",
+            "from_step": "Biorisk Search"
+          },
+          "name": "Toxin1b",
+          "description": "SmallImportantFlag",
+          "ranges": [
             {
               "e_value": 1e-22,
               "match_start": 1,
@@ -565,13 +583,13 @@
             ]
           }
         },
-        "Benign1": {
+        "BENIGNPROT": {
           "recommendation": {
             "status": "Flag (Cleared)",
             "from_step": "Benign Protein Search"
           },
-          "name": "Benign1",
-          "description": "TEST_BENIGN_DESCRIPTION",
+          "name": "BENIGNPROT",
+          "description": "",
           "ranges": [
             {
               "e_value": 9.999999999999999e-27,

--- a/commec/tests/test_screen.py
+++ b/commec/tests/test_screen.py
@@ -42,27 +42,27 @@ def test_functional_screen(tmp_path, request):
     functional_test.add_query("FCTEST1", 600)
 
     #Biorisk
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 7, 95, "Toxin1", "ShouldntClear", 11111, description="LargeAreaFlag", score = 500, regulated = True, superkingdom = "Viruses", species = "horriblus", evalue = 1e-21)
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 34, 65, "Toxin1", "ShouldntClear", 22222, description="SmallImportantFlag", score = 1000, regulated = True, superkingdom = "Viruses", species = "extra-horriblus", evalue = 1e-22)
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 49, 80, "Toxin1", "ShouldTrim", 33333, description="SmallUnimportantTRIM", score = 100, regulated = True, superkingdom = "Viruses", species = "unimporticus", evalue = 1e-23)
+    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 7, 95, "Toxin1a", "ShouldntClear", 11111, description="LargeAreaFlag", score = 500, regulated = True, superkingdom = "Viruses", species = "horriblus", evalue = 1e-21)
+    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 34, 65, "Toxin1b", "ShouldntClear", 22222, description="SmallImportantFlag", score = 1000, regulated = True, superkingdom = "Viruses", species = "extra-horriblus", evalue = 1e-22)
+    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 49, 80, "Toxin1c", "ShouldTrim", 33333, description="SmallUnimportantTRIM", score = 100, regulated = True, superkingdom = "Viruses", species = "unimporticus", evalue = 1e-23)
     functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 109, 191, "Toxin2", "ShouldWarn", 22222, description="WarningExample",score = 1000, regulated = False, superkingdom = "Viruses", species = "extra-horriblus-factor", evalue = 1e-24)
     functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 593, 505, "Toxin3", "ShouldWarn", 11111, description="ReverseExample", score = 500, regulated = False, superkingdom = "Viruses", species = "horriblus-factor", evalue = 1e-25)
     # Protein Taxonomy
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 320, 380, "ShouldntClear", "NR_HIT_FLAG1", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.06)
+    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 320, 380, "NR_HIT_ShouldntClear", "NR_HIT_FLAG1", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.06)
     functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 410, 490, "ShouldClearBySynBio", "NR_HIT_FLAG2", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.07)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 410, 500, "ShouldntClear", "NR_HIT_FLAG3", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.08)
+    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 410, 500, "NR_HIT2_ShouldntClear", "NR_HIT_FLAG3", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.08)
     functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 310, 370, "ShouldClear", "NR_HIT_FLAG4", "12346", regulated = True, superkingdom = "Viruses", species = "fine-icus", evalue = 0.09)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixedReg", "NR_HIT_MIXED1", "12347", regulated = True, superkingdom = "Viruses", species = "danger-poop", evalue = 0.10)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixednonReg", "NR_HIT_MIXED2", "12348", regulated = False, superkingdom = "Bacteria", species = "cute-happy-bacter", evalue = 0.11)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixedNonReg", "NR_HIT_MIXED3", "12349", regulated = False, superkingdom = "Bacteria", species = "poopicus", evalue = 0.12)
+    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixedReg1", "NR_HIT_MIXED1", "12347", regulated = True, superkingdom = "Viruses", species = "danger-poop", evalue = 0.10)
+    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixednonReg2", "NR_HIT_MIXED2", "12348", regulated = False, superkingdom = "Bacteria", species = "cute-happy-bacter", evalue = 0.11)
+    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixedNonReg3", "NR_HIT_MIXED3", "12349", regulated = False, superkingdom = "Bacteria", species = "poopicus", evalue = 0.12)
     # Nucleotide Taxonomy
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 220, 280, "SUBJECT", "NT_HIT_FLAG1", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.13)
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 110, 190, "SUBJECT", "NT_HIT_FLAG2", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.14)
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 110, 200, "SUBJECT", "NT_HIT_FLAG3", "12350", regulated = True, superkingdom = "Viruses", evalue = 0.15)
+    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 220, 280, "SUBJECT_1", "NT_HIT_FLAG1", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.13)
+    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 110, 190, "SUBJECT_2", "NT_HIT_FLAG2", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.14)
+    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 110, 200, "SUBJECT_3", "NT_HIT_FLAG3", "12350", regulated = True, superkingdom = "Viruses", evalue = 0.15)
     functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 310, 390, "Main", "NT_HIT_MIXED", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.16)
     functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 310, 390, "NonRegMixedWithMain", "NT_HIT_MIXED2", "12346", regulated = False, superkingdom = "Bacteria", evalue = 0.17)
     # Low Concern
-    functional_test.add_hit(ScreenStep.LOW_CONCERN_PROTEIN, "FCTEST1", 202, 370, "Benign1", "Benign1", description = "BenignHMMClear", evalue = 1e-26)
+    functional_test.add_hit(ScreenStep.LOW_CONCERN_PROTEIN, "FCTEST1", 202, 370, "BENIGNPROT", "Benign1", description = "BenignHMMClear", evalue = 1e-26)
     functional_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "FCTEST1", 50, 150, "BENIGNRNA", "12346", description = "BenignCMTestOutput", evalue = 1e-27)
     functional_test.add_hit(ScreenStep.LOW_CONCERN_DNA, "FCTEST1", 410, 480, "BENIGNSYNBIO", "210", description = "BenignBlastClear", evalue = 1e-28)
 
@@ -124,10 +124,10 @@ def test_different_regions(tmp_path):
     #encode_screen_data_to_json(result, "../test_output.json")
 
     num_hits = len(result.queries["query1"].hits)
-    num_regions = len(result.queries["query1"].hits["RR55"].ranges)
+    num_regions = len(result.queries["query1"].hits["RegRepeat"].ranges)
     status = result.queries["query1"].status.screen_status
     assert  num_hits == 2, f"Expected two hits, got {num_hits}."
-    assert  num_regions == 5, (f"Number of ranges [{num_regions}] in hit `RR55` for "
+    assert  num_regions == 5, (f"Number of ranges [{num_regions}] in hit `RegRepeat` for "
                             " `query1` not equal to expected number (5).")
     assert status == ScreenStatus.FLAG, ("Expected status is to FLAG, current status"
                                         f" is {status}, likely multiple region clearing issue.")


### PR DESCRIPTION
The hit name is more likely than accession to not be unique, providing a better user experience for parsing verbose repeated like sequences, so we now collapse hits based on name. 

The functional test outputs were carefully curated to ensure that the result was the same, and required changes to some hit names to ensure that the benign checks treated appropriate regions separately. Also minor updates to the checks for testing regions in screen.

Whilst consider the name or accession as a collapse point, this created complications in checking, as the accession is not typically stored to be checked. In either case, the accession tends to be more unique, and more often the name is shared with unique accessions, rather than the other way around.
