### PR TITLE
Species html truncation

### DIFF
--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -220,11 +220,11 @@ def generate_outcome_string(query : QueryResult, hit : HitResult) -> str:
                 n_regulated_eukaryotes += int(r["regulated_eukaryotes"])
                 n_regulated_bacteria += int(r["regulated_bacteria"])
                 n_regulated_viruses += int(r["regulated_viruses"])
-                regulated_taxids.extend(r["regulated_taxa"])
+                regulated_taxids.extend([x["species"] for x in r["regulated_taxa"]])
                 non_regulated_taxids.extend(r["non_regulated_taxa"])
             
-            for entry in regulated_taxids:
-                regulated_species.append(entry["species"])
+            for entry in set(regulated_taxids):
+                regulated_species.append(entry)
             
             domain_string = " across multiple domains."
             if n_regulated_bacteria > 0 and n_regulated_viruses == 0 and n_regulated_eukaryotes == 0:


### PR DESCRIPTION
## Background
<img width="1940" height="895" alt="image" src="https://github.com/user-attachments/assets/46614ee3-d1a8-48e7-b918-2e939ed4bcbb" />

## Changes
<img width="1673" height="382" alt="image" src="https://github.com/user-attachments/assets/b6ff622e-a137-4927-b3e1-2e388d58f38d" />

### New features
* Many species names that are the same are no longer endlessly repeated in the output for html overtext.