### PR TITLE
Forces all imported query name related columns to be of datatype str,…

### DIFF
--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -229,6 +229,7 @@ def read_blast(blast_file: str | os.PathLike | BinaryIO | TextIO) -> pd.DataFram
     blast["log evalue"] = -np.log10(pd.to_numeric(blast["evalue"]) + 1e-300)
     blast["q. coverage"] = abs(blast["q. end"] - blast["q. start"]) / blast["query length"].max()
     blast["s. coverage"] = abs(blast["s. end"] - blast["s. start"]) / blast["subject length"]
+    blast["query acc."] = blast["query acc."].astype(str)
 
     blast = blast[blast["subject tax ids"].notna()]
     blast = blast.reset_index(drop=True)

--- a/commec/tools/cmscan.py
+++ b/commec/tools/cmscan.py
@@ -108,5 +108,6 @@ def readcmscan(fileh):
     cmscan["score"] = pd.to_numeric(cmscan["score"])
     cmscan["seq from"] = pd.to_numeric(cmscan["seq from"])
     cmscan["seq to"] = pd.to_numeric(cmscan["seq to"])
+    cmscan["query name"] = cmscan["query name"].astype(str)
 
     return cmscan

--- a/commec/tools/hmmer.py
+++ b/commec/tools/hmmer.py
@@ -120,6 +120,7 @@ def readhmmer(fileh):
     hmmer["ali from"] = pd.to_numeric(hmmer["ali from"])
     hmmer["ali to"] = pd.to_numeric(hmmer["ali to"])
     hmmer["qlen"] = pd.to_numeric(hmmer["qlen"])
+    hmmer["query name"] = hmmer["query name"].astype(str)
     # Extract the frame information.
     hmmer["frame"] = hmmer["query name"].str.split('_').str[-1].astype(int)
     return hmmer


### PR DESCRIPTION
## Background
There are no protections when import data from blast / cmscan / hmmer to ensure that the datatype for the query name was string, and it may be that query names of a single numerical character i.e.e '0' or '5' are being imported as chars or ints, leading to issues with parsing their respective row data to the query objects imported from fasta.

This might address this by forcing the datatypes on import.