### PR TITLE
Synchronisation for low_concern database rna update

### DIFF
--- a/commec/screen-default-config.yaml
+++ b/commec/screen-default-config.yaml
@@ -14,11 +14,11 @@ databases:
     path: '{default}nt_blast/core_nt'
   low_concern:
     rna:
-      path: '{default}low_concern/rna/benign.cm'
+      path: '{default}low_concern/rna/low_concern.cm'
     dna:
-      path: '{default}low_concern/dna/benign.fasta'
+      path: '{default}low_concern/dna/low_concern.fasta'
     protein:
-      path: '{default}low_concern/protein/benign.hmm'
+      path: '{default}low_concern/protein/low_concern.hmm'
     taxids: "{default}low_concern/vax_taxids.txt"
     annotations: '{default}low_concern/low_concern_annotations.tsv'
   taxonomy:

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -19,9 +19,9 @@ def expected_defaults():
         },
         "databases": {
             "low_concern": {
-                "rna": {"path": "commec-dbs/low_concern/rna/benign.cm"},
-                "dna": {"path": "commec-dbs/low_concern/dna/benign.fasta"},
-                "protein": {"path": "commec-dbs/low_concern/protein/benign.hmm"},
+                "rna": {"path": "commec-dbs/low_concern/rna/low_concern.cm"},
+                "dna": {"path": "commec-dbs/low_concern/dna/low_concern.fasta"},
+                "protein": {"path": "commec-dbs/low_concern/protein/low_concern.hmm"},
                 "annotations": 'commec-dbs/low_concern/low_concern_annotations.tsv',
                 "taxids": "commec-dbs/low_concern/vax_taxids.txt"
             },
@@ -73,9 +73,9 @@ def expected_updated_from_custom_yaml():
         },
         "databases": {
             "low_concern": {
-                "rna": {"path": "commec-dbs/low_concern/rna/benign.cm"},
-                "dna": {"path": "commec-dbs/low_concern/dna/benign.fasta"},
-                "protein": {"path": "commec-dbs/low_concern/protein/benign.hmm"},
+                "rna": {"path": "commec-dbs/low_concern/rna/low_concern.cm"},
+                "dna": {"path": "commec-dbs/low_concern/dna/low_concern.fasta"},
+                "protein": {"path": "commec-dbs/low_concern/protein/low_concern.hmm"},
                 "annotations": 'commec-dbs/low_concern/low_concern_annotations.tsv',
                 "taxids": "commec-dbs/low_concern/vax_taxids.txt"
             },


### PR DESCRIPTION
An [upcoming low concern rna database update](https://github.com/ibbis-bio/commec-databases/pull/12) also corrects the use of the term benign at the filename level. This fix simply ensures that the correct filenames are being pointed to as defaults in the default configuration yaml.