### PR TITLE
Support evalportal format in commec flag output

### DIFF
--- a/commec/flag.py
+++ b/commec/flag.py
@@ -51,6 +51,13 @@ def add_args(parser: argparse.ArgumentParser):
         default=None,
         help="Output directory name (defaults to directory if not provided)",
     )
+    parser.add_argument(
+        "-e",
+        "--evalportal-format",
+        dest="evalportal_format",
+        action="store_true",
+        help="Output format compatible with the IBBIS sceening evlauation portal",
+    )
     return parser
 
 def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
@@ -162,16 +169,25 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
 
     return results
 
-def write_output_csv(output_dir : str | os.PathLike, status : dict):
+
+def write_output_csv(output_dir: str | os.PathLike, status: dict, evalportal_format: bool):
     """
     Write flag data results to an output CSV file.
     -----
     `output_dir` [str | os.PathLike] : Desired output directory to write the output csv into.
     `status`     [dict-like object]  : converted to pandas dataframe, sorted, and output to csv.
+    `evalportal_format` [bool]       : If True, convert flag values to binary and rename columns.
     """
     status_file = os.path.join(output_dir, "screen_pipeline_status.csv")
     status_df = pd.DataFrame(status)
     status_df = status_df.map(lambda x: ";".join(sorted(x)) if isinstance(x, set) else x)
+
+    if evalportal_format:
+        # Using a "strict" mode coverting Flag/Warning to 1, and everything else to 0.
+        status_df["flag"] = status_df["flag"].map(
+            lambda x: 1 if x == "Flag" or x == "Warning" else 0)
+        status_df = status_df.rename(columns={"name": "UUID", "flag": "Flag"})
+
     status_df.to_csv(status_file, index=False)
     print(f"Pipeline step status written to {status_file}")
 
@@ -186,6 +202,7 @@ def run(args: argparse.Namespace):
     search_dir = args.directory
     search_recursive = args.recursive
     output_dir = args.output or os.path.dirname(search_dir)
+    evalportal_format = args.evalportal_format
 
     search_pattern = "**/*.json" if search_recursive else "*.json"
     screen_paths = glob.glob(os.path.join(search_dir, search_pattern), recursive=search_recursive)
@@ -198,7 +215,7 @@ def run(args: argparse.Namespace):
         result = read_flags_from_json(file_path)
         screen_status.extend(result)
 
-    write_output_csv(output_dir, screen_status)
+    write_output_csv(output_dir, screen_status, evalportal_format)
 
 
 def main():

--- a/commec/tests/test_flag.py
+++ b/commec/tests/test_flag.py
@@ -31,3 +31,30 @@ def test_flag(tmp_path):
     )
     actual_status = status_output.read_text()
     assert expected_status.strip() == actual_status.strip()
+
+
+def test_evalportal_format(tmp_path):
+    """Testing flag output in evalportal format."""
+    parser = argparse.ArgumentParser()
+    add_args(parser)
+    args = parser.parse_args([SCREEN_DIR, "-o", str(tmp_path), "-r", "-e"])
+    run(args)
+
+    # Check if the output file exists
+    status_output = tmp_path / "screen_pipeline_status.csv"
+    assert status_output.exists()
+
+    expected_status = textwrap.dedent(
+        f"""\
+        UUID,filepath,Flag,biorisk,protein,nucleotide,low_concern,virus_flag,bacteria_flag,eukaryote_flag,low_concern_protein,low_concern_rna,low_concern_dna,rationale
+        FLAG_TEST_01,{SCREEN_DIR}/flag_tests.json,1,Flag,Pass,Pass,Flag,False,False,False,False,False,False,
+        FLAG_TEST_02,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,True,False,False,False,False,False,
+        FLAG_TEST_03,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,True,False,False,False,False,
+        FLAG_TEST_04,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
+        FLAG_TEST_05,{SCREEN_DIR}/flag_tests.json,1,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
+        FLAG_TEST_06,{SCREEN_DIR}/flag_tests.json,0,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
+        FCTEST1,{SCREEN_DIR}/functional.json,1,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
+        """
+    )
+    actual_status = status_output.read_text()
+    assert expected_status.strip() == actual_status.strip()    


### PR DESCRIPTION
## Background
The [IBBIS screening evaluation portal](https://evalportal.ibbis.bio/) requires a CSV or TSV with a `UUID` query name column and a `Flag` boolean column where positive inputs are 1 and negative inputs are 0.


## Changes

### New features
* This PR adds evalportal format support to `commec flag` output through the `-e, --evalportal-format` option. 
* Also added a `test_evalportal_format()` based on the existing `test_flag()`.
 
Note: Uses a "commec_strict" approach following this [paper](https://www.biorxiv.org/content/10.1101/2025.05.30.655379v1):

> To reach their standards, NIST had to use a "commec_strict" approach of counting "warning" as "flag" ― this is because taxonomic hits were getting filtered out by unclassified sequences. We should ignore unclassified sequences and treat "warning + mixed taxonomy" as "flag".

We should relax this approach when the issue of unclassified taxa is fixed.

## NIST Study guide example
Input JSON: [sample_NIST-screening-dataset-blinded-seqs.output.json](https://github.com/user-attachments/files/24164396/sample_NIST-screening-dataset-blinded-seqs.output.json)

Command: `commec flag --evalportal-format <directory containing the .json file>`

Output: [screen_pipeline_status.csv](https://github.com/user-attachments/files/24164425/screen_pipeline_status.csv)

Evaluation Portal result:
<img width="1313" height="545" alt="image" src="https://github.com/user-attachments/assets/d806cbba-5c69-4272-92a3-e0bf965f996f" />
