### PR TITLE
Yaml paths fix

### DIFF
--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -251,38 +251,39 @@ class ScreenIO:
         This script will update the dictionary to propagate these substitutions.
         If a database directory is provided, it will override the base_path provided in the yaml.
         """
-        if self.config.get("base_paths"):
-            try:
-                base_paths = self.config["base_paths"]
-                if db_dir_override is not None:
-                    logger.debug(f"Command line arguments updated base databases directory: {db_dir_override}")
-                    base_paths["default"] = db_dir_override
-                else:
-                    self.db_dir = base_paths["default"]
+        def recursive_format(nested_yaml, base_paths):
+            """
+            Recursively apply string formatting to read paths from nested yaml config dicts.
+            """
+            if isinstance(nested_yaml, dict):
+                return {key : recursive_format(value, base_paths) 
+                        for key, value in nested_yaml.items()}
+            if isinstance(nested_yaml, str):
+                try:
+                    return nested_yaml.format(**base_paths)
+                except KeyError as e:
+                    raise ValueError(
+                        f"Unknown base path key referenced in path: {nested_yaml}"
+                    ) from e
+            return nested_yaml
+            
+        try:
+            # Ensure all the base paths end with a separator
+            for key, value in self.config["base_paths"].items():
+                self.config["base_paths"][key] = os.path.join(value,'')
+            self.config["base_paths"] = recursive_format(self.config["base_paths"], self.config["base_paths"])
+            self.config = recursive_format(self.config, self.config["base_paths"])
 
-                # Ensure all the base paths end with a separator
-                for key, value in base_paths.items():
-                    base_paths[key] = os.path.join(value,'')
+            # Restores legacy behaviour with -d in commec screen CLI, with no yaml.
+            if db_dir_override is not None:
+                logger.debug("Command line arguments updated base databases directory: %s", db_dir_override)
+                self.config["base_paths"]["default"] = db_dir_override
+            else:
+                self.db_dir = self.config["base_paths"]["default"]
 
-                def recursive_format(nested_yaml, base_paths):
-                    """
-                    Recursively apply string formatting to read paths from nested yaml config dicts.
-                    """
-                    if isinstance(nested_yaml, dict):
-                        return {key : recursive_format(value, base_paths) 
-                                for key, value in nested_yaml.items()}
-                    if isinstance(nested_yaml, str):
-                        try:
-                            return nested_yaml.format(**base_paths)
-                        except KeyError as e:
-                            raise ValueError(
-                                f"Unknown base path key referenced in path: {nested_yaml}"
-                            ) from e
-                    return nested_yaml
-
-                self.config = recursive_format(self.config, base_paths)
-            except TypeError:
-                pass
+        except TypeError as e:
+            logger.error("Encountered unexpected TypeError during yaml config base path substitution: %s", e)
+            pass
 
     @staticmethod
     def _get_output_prefixes(input_file: str | os.PathLike, prefix_arg=None) -> str:

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -268,18 +268,20 @@ class ScreenIO:
             return nested_yaml
             
         try:
-            # Ensure all the base paths end with a separator
-            for key, value in self.config["base_paths"].items():
-                self.config["base_paths"][key] = os.path.join(value,'')
-            self.config["base_paths"] = recursive_format(self.config["base_paths"], self.config["base_paths"])
-            self.config = recursive_format(self.config, self.config["base_paths"])
-
             # Restores legacy behaviour with -d in commec screen CLI, with no yaml.
             if db_dir_override is not None:
                 logger.debug("Command line arguments updated base databases directory: %s", db_dir_override)
                 self.config["base_paths"]["default"] = db_dir_override
             else:
                 self.db_dir = self.config["base_paths"]["default"]
+
+            # Ensure all the base paths end with a separator
+            for key, value in self.config["base_paths"].items():
+                self.config["base_paths"][key] = os.path.join(value,'')
+            
+            # Recursively format all paths
+            self.config["base_paths"] = recursive_format(self.config["base_paths"], self.config["base_paths"])
+            self.config = recursive_format(self.config, self.config["base_paths"])
 
         except TypeError as e:
             logger.error("Encountered unexpected TypeError during yaml config base path substitution: %s", e)

--- a/commec/utils/dict_utils.py
+++ b/commec/utils/dict_utils.py
@@ -6,13 +6,16 @@ Static functions useful for dealing with common dictionary tasks.
 
 @staticmethod
 def deep_update(to_update: dict[str, any], 
-                has_updates: dict[str, any]) -> tuple[
+                has_updates: dict[str, any],
+                force: bool = False) -> tuple[
                     dict[str,any], 
                     list[tuple[str,any]]]:
     """
     Recursively update a nested dictionary without completely overwriting nested dictionaries.
     Only already existing keys are updated. Any keys not existing in the dictionary
     to be updated are returned as a list of rejected key value pairs.
+
+    The highly customizable base_paths dict is checked, and entries preserved.
     -----
     Inputs:
     * to_update : dict[str, any] Dictionary to be updated.
@@ -29,10 +32,11 @@ def deep_update(to_update: dict[str, any],
     for key, value in has_updates.items():
         # If both values are dictionaries, recursively update
         if key in updated and isinstance(updated[key], dict) and isinstance(value, dict):
-            updated[key], additional_rejects = deep_update(updated[key], value)
+            force_next = (key == "base_paths")
+            updated[key], additional_rejects = deep_update(updated[key], value, force_next)
             rejected.extend(additional_rejects)
-        # If not a dictionary, just copy the value.
-        elif key in updated:
+        # If not a dictionary, just copy the value, forced if required.
+        elif key in updated or force:
             updated[key] = value
         # If not present, we log an unexpected input one.
         else:

--- a/commec/utils/dict_utils.py
+++ b/commec/utils/dict_utils.py
@@ -7,7 +7,7 @@ Static functions useful for dealing with common dictionary tasks.
 @staticmethod
 def deep_update(to_update: dict[str, any], 
                 has_updates: dict[str, any],
-                force: bool = False) -> tuple[
+                accept_new_keys: bool = False) -> tuple[
                     dict[str,any], 
                     list[tuple[str,any]]]:
     """
@@ -32,11 +32,11 @@ def deep_update(to_update: dict[str, any],
     for key, value in has_updates.items():
         # If both values are dictionaries, recursively update
         if key in updated and isinstance(updated[key], dict) and isinstance(value, dict):
-            force_next = (key == "base_paths")
-            updated[key], additional_rejects = deep_update(updated[key], value, force_next)
+            accept_next : bool = (key == "base_paths")
+            updated[key], additional_rejects = deep_update(updated[key], value, accept_next)
             rejected.extend(additional_rejects)
         # If not a dictionary, just copy the value, forced if required.
-        elif key in updated or force:
+        elif key in updated or accept_new_keys:
             updated[key] = value
         # If not present, we log an unexpected input one.
         else:


### PR DESCRIPTION
## Background
When using .yaml configuration files for commec screen, only the base_paths->default, was being saved and used for quick substitution into other paths, and any custom additions were being overwritten due to conflicting code that ensured that the configuration yaml kept the same format and entries as the example/defaults yaml. 

These changes ensure that any custom paths in the base_paths key are kept, and then subsquently used not only on the whole yaml, but first on the base_paths themselves, to ensure that the following yaml example is valid:

```yaml
base_paths:
  default: '/mnt/data/ibbis/commec-dbs/'
  lowconcernfiles: '{default}low_concern/'
  custom: '/mnt/data/ibbis/repo/control-lists/'
databases:
  biorisk:
    path: '{default}biorisk/biorisk.hmm'
    taxids: "{default}biorisk/reg_taxids.txt"
    annotations: '{default}biorisk/biorisk_annotations.csv'
  regulated_protein:
    blast:
      path: '{default}nr_igem_examples/nr_igem_examples'
    diamond:
      path: '{default}nr_dmnd/nr.dmnd'
  regulated_nt:
    path: '{default}nt_igem_examples/nt_igem_examples'
  low_concern:
    rna:
      path: '{lowconcernfiles}rna/benign.cm'
    dna:
      path: '{lowconcernfiles}dna/benign.fasta'
    protein:
      path: '{lowconcernfiles}protein/benign.hmm'
    taxids: "{lowconcernfiles}vax_taxids.txt"
    annotations: '{lowconcernfiles}low_concern_annotations.tsv'
  taxonomy:
      path: "{default}taxonomy/"
  control_lists:
      path: "{custom}control_lists_build/control_lists"
      regions : "all"
threads: 4
diamond_jobs: null
do_cleanup: False
force: False
skip_taxonomy_search: False
protein_search_tool: 'blastx'
resume: False
skip_nt_search: False
verbose: False
```

### Bug fixes
* Fixes yaml base path substitution bugs.

### Relevant logs, error messages, etc.
* Added error logging for type errors to be displayed, rather than passed.