### PR TITLE
Biorisk E-Value Filter

### DIFF
--- a/commec/config/constants.py
+++ b/commec/config/constants.py
@@ -4,6 +4,14 @@
 # SCREENING
 MINIMUM_QUERY_LENGTH = 41
 
+# BIORISK E-VALUE FILTERING
+# Sequences shorter than this threshold use a length-dependent E-value cutoff.
+BIORISK_SHORT_QUERY_NT_THRESHOLD = 200
+# Exponent for the length-dependent E-value formula: E < 1 / (1 + L^EXPONENT)
+BIORISK_SHORT_QUERY_EVALUE_EXPONENT = 2.598
+# E-value cutoff applied to sequences at or above the length threshold.
+BIORISK_LONG_QUERY_EVALUE_THRESHOLD = 1e-20
+
 # I/O
 DEFAULT_CONFIG_YAML_PATH = "screen-default-config.yaml"
 MAXIMUM_FILENAME_SIZE = 255

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -10,6 +10,11 @@ import logging
 import os
 import pandas as pd
 from commec.config.query import Query
+from commec.config.constants import (
+    BIORISK_SHORT_QUERY_NT_THRESHOLD,
+    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
+    BIORISK_LONG_QUERY_EVALUE_THRESHOLD,
+)
 from commec.tools.hmmer import (
     readhmmer,
     remove_overlaps,
@@ -64,6 +69,30 @@ def read_biorisk_annotations(hmm_folder_csv) -> pd.DataFrame:
     lookup.fillna(False, inplace=True)
     return lookup
 
+def biorisk_evalue_filter(hmmer: pd.DataFrame) -> pd.DataFrame:
+    """
+    Filter hmmscan hits by E-value, using a length-dependent threshold for short queries.
+
+    For queries shorter than BIORISK_SHORT_QUERY_NT_THRESHOLD nucleotides, the cutoff is:
+        E-value < 1 / (1 + nt_qlen ^ BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+    For all other queries the cutoff is BIORISK_LONG_QUERY_EVALUE_THRESHOLD.
+
+    Expects numeric 'E-value' and 'nt_qlen' columns; coerces them if needed.
+    Returns a filtered copy of the input DataFrame.
+    """
+    df = hmmer.copy()
+    df['E-value'] = pd.to_numeric(df['E-value'], errors='coerce')
+    df['nt_qlen'] = pd.to_numeric(df['nt_qlen'], errors='coerce')
+
+    short_query = df['nt_qlen'] < BIORISK_SHORT_QUERY_NT_THRESHOLD
+    short_cutoff = 1 / (1 + df['nt_qlen'] ** BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+
+    mask = (short_query & (df['E-value'] < short_cutoff)) | \
+           (~short_query & (df['E-value'] < BIORISK_LONG_QUERY_EVALUE_THRESHOLD))
+
+    return df[mask]
+
+
 def parse_biorisk_hits(search_handler : HmmerHandler,
                                       biorisk_annotations_file : str | os.PathLike,
                                       data : ScreenResult,
@@ -100,13 +129,12 @@ def parse_biorisk_hits(search_handler : HmmerHandler,
     # Read in Output, and parse.
     hmmer : pd.DataFrame = readhmmer(search_handler.out_file)
     logger.debug("Biorisk Import: shape: %s preview:\n%s", hmmer.shape, hmmer.head())
-    keep1 = [i for i, x in enumerate(hmmer['E-value']) if x < 1e-20]
-    hmmer = hmmer.iloc[keep1,:]
-    logger.debug("Biorisk Filterd by E-Value: shape: %s preview:\n%s", 
-                 hmmer.shape, hmmer.head())
     append_nt_querylength_info(hmmer, queries)
     logger.debug("Appended Query NT length: shape: %s preview:\n%s", 
                  hmmer.shape, hmmer[["query name","nt_qlen"]].head())
+    hmmer = biorisk_evalue_filter(hmmer)
+    logger.debug("Biorisk Filterd by E-Value: shape: %s preview:\n%s", 
+                 hmmer.shape, hmmer.head())
     recalculate_hmmer_query_coordinates(hmmer)
     logger.debug("Recalculated AA to NT coords: shape: %s preview:\n%s", 
                  hmmer.shape, hmmer[["ali from","ali to","q. start","q. end"]].head())

--- a/commec/tests/test_check_biorisk.py
+++ b/commec/tests/test_check_biorisk.py
@@ -4,9 +4,14 @@ import pandas as pd
 import os
 from Bio.SeqRecord import SeqRecord, Seq
 
-from commec.screeners.check_biorisk import parse_biorisk_hits, HmmerHandler
+from commec.screeners.check_biorisk import biorisk_evalue_filter, parse_biorisk_hits, HmmerHandler
 from commec.config.result import ScreenResult
 from commec.config.query import Query
+from commec.config.constants import (
+    BIORISK_SHORT_QUERY_NT_THRESHOLD,
+    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
+    BIORISK_LONG_QUERY_EVALUE_THRESHOLD,
+)
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
@@ -58,3 +63,130 @@ def test_check_biorisk_return_codes(annotations_exists, has_empty_output, has_hi
 
         # Check the result
         assert result == expected_return
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_hmmer(nt_qlen: int, evalue: float) -> pd.DataFrame:
+    """Return a minimal single-row hmmscan DataFrame."""
+    return pd.DataFrame({"E-value": [evalue], "nt_qlen": [nt_qlen]})
+
+
+def _short_cutoff(nt_qlen: float) -> float:
+    """Length-dependent E-value cutoff for short queries."""
+    return 1 / (1 + nt_qlen ** BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+
+
+# ---------------------------------------------------------------------------
+# biorisk_evalue_filter — short-query regime (nt_qlen < threshold)
+# ---------------------------------------------------------------------------
+
+class TestBioriskEvalueFilterShortQuery:
+    """nt_qlen below BIORISK_SHORT_QUERY_NT_THRESHOLD uses the power-law cutoff."""
+
+    def test_short_query_passes_when_evalue_below_cutoff(self):
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 0.5  # clearly below cutoff
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 1
+
+    def test_short_query_filtered_when_evalue_above_cutoff(self):
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 2.0  # clearly above cutoff
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 0
+
+    def test_very_short_query_uses_power_law_not_long_threshold(self):
+        """A very short query with E-value below long threshold but above short
+        cutoff should be filtered out — not admitted by the long-query rule."""
+        nt_qlen = 10
+        # For nt_qlen=10 the short cutoff is ~1/(1+10^2.598) ≈ 2.5e-3; use a
+        # value that is below 1e-20 (long threshold) but above short cutoff.
+        # That is impossible to construct, so instead confirm the short rule
+        # dominates: use an evalue above the short cutoff and verify it is dropped.
+        evalue = _short_cutoff(nt_qlen) * 2
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 0
+
+    def test_query_just_below_threshold_uses_short_rule(self):
+        nt_qlen = BIORISK_SHORT_QUERY_NT_THRESHOLD - 1
+        evalue = _short_cutoff(nt_qlen) * 0.5
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 1
+
+class TestBioriskEvalueFilterLongQuery:
+    """nt_qlen at or above BIORISK_SHORT_QUERY_NT_THRESHOLD uses the fixed cutoff."""
+
+    def test_long_query_passes_when_evalue_below_threshold(self):
+        nt_qlen = BIORISK_SHORT_QUERY_NT_THRESHOLD
+        evalue = BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 0.1
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 1
+
+    def test_long_query_filtered_when_evalue_above_threshold(self):
+        nt_qlen = BIORISK_SHORT_QUERY_NT_THRESHOLD
+        evalue = BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 10
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 0
+
+class TestBioriskEvalueFilterMultiRow:
+    """Tests covering mixed DataFrames and edge cases."""
+
+    def test_mixed_rows_only_passing_rows_retained(self):
+        nt_qlen_short = 100
+        nt_qlen_long = 500
+        df = pd.DataFrame({
+            "E-value": [
+                _short_cutoff(nt_qlen_short) * 0.5,   # short, passes
+                _short_cutoff(nt_qlen_short) * 2.0,   # short, filtered
+                BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 0.1,  # long, passes
+                BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 10,   # long, filtered
+            ],
+            "nt_qlen": [nt_qlen_short, nt_qlen_short, nt_qlen_long, nt_qlen_long],
+        })
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 2
+
+    def test_empty_dataframe_returns_empty(self):
+        df = pd.DataFrame({"E-value": [], "nt_qlen": []})
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 0
+
+    def test_string_columns_are_coerced_to_numeric(self):
+        """readhmmer returns string columns; filter must coerce them."""
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 0.5
+        df = pd.DataFrame({"E-value": [str(evalue)], "nt_qlen": [str(nt_qlen)]})
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 1
+
+    def test_non_numeric_evalues_are_dropped(self):
+        """Rows with non-coercible E-values become NaN and should be excluded."""
+        df = pd.DataFrame({"E-value": ["not_a_number"], "nt_qlen": [100]})
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 0
+
+    def test_input_dataframe_is_not_mutated(self):
+        """The function must return a copy; the original dtypes must be unchanged."""
+        df = pd.DataFrame({"E-value": ["1e-25"], "nt_qlen": ["500"]})
+        original_dtype_evalue = df["E-value"].dtype
+        original_dtype_qlen = df["nt_qlen"].dtype
+        _ = biorisk_evalue_filter(df)
+        assert df["E-value"].dtype == original_dtype_evalue
+        assert df["nt_qlen"].dtype == original_dtype_qlen
+
+    def test_extra_columns_are_preserved(self):
+        """Columns beyond E-value and nt_qlen must survive the filter unchanged."""
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 0.5
+        df = pd.DataFrame({
+            "E-value": [evalue],
+            "nt_qlen": [nt_qlen],
+            "target name": ["some_target"],
+            "query name": ["some_query"],
+        })
+        result = biorisk_evalue_filter(df)
+        assert "target name" in result.columns
+        assert result["target name"].iloc[0] == "some_target"


### PR DESCRIPTION
## Background
@brmagalis did a bunch of work on the best ways to modify the E-value filter cut-offs for the biorisk screen results. This PR takes those changes and implements them into Commec for deployment with the latest Biorisk Database update.

## Changes
Three constants (in constants.py) to help hard-coded parameters for check_biorisk:

`BIORISK_SHORT_QUERY_NT_THRESHOLD` = 200 — length boundary between the two regimes
`BIORISK_SHORT_QUERY_EVALUE_EXPONENT` = 2.598 — exponent for the length-dependent formula
`BIORISK_LONG_QUERY_EVALUE_THRESHOLD` = 1e-20 — cutoff for longer sequences

`biorisk_evalue_filter(hmmer: pd.DataFrame) -> pd.DataFrame` function that uses vectorised pandas boolean masking (no row iteration), handles the coercions internally, and returns a filtered copy of the dataframe, used in check_biorisk.py in a way to match other processing style steps:

```python
    # Read in Output, and parse.
    hmmer : pd.DataFrame = readhmmer(search_handler.out_file)
    logger.debug("Biorisk Import: shape: %s preview:\n%s", hmmer.shape, hmmer.head())
    append_nt_querylength_info(hmmer, queries)
    logger.debug("Appended Query NT length: shape: %s preview:\n%s", 
                 hmmer.shape, hmmer[["query name","nt_qlen"]].head())
    hmmer = biorisk_evalue_filter(hmmer)
    logger.debug("Biorisk Filterd by E-Value: shape: %s preview:\n%s", 
                 hmmer.shape, hmmer.head())
    recalculate_hmmer_query_coordinates(hmmer)
    logger.debug("Recalculated AA to NT coords: shape: %s preview:\n%s", 
                 hmmer.shape, hmmer[["ali from","ali to","q. start","q. end"]].head())
    hmmer = remove_overlaps(hmmer)
    logger.debug("Removed overlaps: shape: %s preview:\n%s", hmmer.shape, hmmer.head())
```

### New features
* Individual Biorisk hits are now filtered based on E-value in a query length dependent manner.


## Relevant logs, error messages, etc.
Tests were added for the new biorisk_evalue_filter() function.
A run on igem test samples ran successfully, and returned the following summary:
```
 >> SUMMARY : 
                    query      overall      biorisk  taxonomy_aa  taxonomy_nt      cleared
BBa_K346005_A_19501_Devic         Flag         Flag         Skip         Skip         Flag
BBa_K346035_A_19509_Compo         Flag         Flag         Skip         Skip         Flag
BBa_J10063_P_24735_Report      Warning      Warning         Skip         Skip      Warning
BBa_K133012_A_13220_Inter         Flag         Flag         Skip         Skip         Flag
BBa_K380009_A_20830_Codin         Flag         Flag         Skip         Skip         Flag
BBa_M1307_P_8104_Project_         Flag         Flag         Skip         Skip         Flag
BBa_K620001_P_22737_Codin      Warning         Pass         Skip         Skip         Pass
BBa_S04610_P_22826_Interm         Flag         Flag         Skip         Skip         Flag
BBa_J78002_P_15509_Transl      Warning      Warning         Skip         Skip      Warning
BBa_K891234_P_27921_Codin      Warning         Pass         Skip         Skip         Pass
BBa_K080006_P_12158_Regul      Warning         Pass         Skip         Skip         Pass
BBa_K747100_P_27319_Plasm      Warning      Warning         Skip         Skip      Warning
BBa_K747101_P_27320_Plasm      Warning      Warning         Skip         Skip      Warning
BBa_K782009_P_26087_Codin      Warning      Warning         Skip         Skip      Warning
BBa_K782040_P_26193_Codin      Warning      Warning         Skip         Skip      Warning
BBa_K318519_P_19569_Devic      Warning         Pass         Skip         Skip         Pass
BBa_K563037_P_23846_Codin      Warning         Pass         Skip         Skip         Pass
BBa_K747040_P_27002_Prote      Warning         Pass         Skip         Skip         Pass
BBa_K581012_P_23179_Codin      Warning         Pass         Skip         Skip         Pass
BBa_K787004_P_27902_Proje      Warning      Warning         Skip         Skip      Warning
BBa_K734006_P_27753_Plasm      Warning      Warning         Skip         Skip      Warning
BBa_K320009_A_19680_Gener      Warning      Warning         Skip         Skip      Warning
BBa_K209429_A_15261_Compo      Warning         Pass         Skip         Skip         Pass
BBa_K731710_P_25411_Plasm      Warning         Pass         Skip         Skip         Pass
BBa_K535007_P_23044_Plasm      Warning         Pass         Skip         Skip         Pass
BBa_I713002_A_10458_Plasm      Warning         Pass         Skip         Skip         Pass
BBa_K901015_P_27772_Devic      Warning      Warning         Skip         Skip      Warning
BBa_J44010_A_7669_Reporte      Warning      Warning         Skip         Skip      Warning
BBa_K081008_A_12110_Trans      Warning      Warning         Skip         Skip      Warning
BBa_K228221_A_14989_Gener      Warning      Warning         Skip         Skip      Warning
BBa_K205004_A_16908_Codin      Warning         Pass         Skip         Skip         Pass
BBa_K257021_A_16536_Compo      Warning         Pass         Skip         Skip         Pass
BBa_K945004_P_27478_Repor      Warning         Pass         Skip         Skip         Pass
BBa_J06126_P_5665__"_--_N      Warning         Pass         Skip         Skip         Pass
```
