### PR TITLE
Remove no-hits warning logic 

### DIFF
--- a/commec/config/query.py
+++ b/commec/config/query.py
@@ -24,7 +24,6 @@ class Query:
         self.non_coding_regions : list[tuple[int, int]] = [] # 1 based coordinates for Non-Coding Regions.
         self.result : QueryResult = None
         self.translations: list[QueryTranslation] = []
-        self.no_hits_warning : bool = True # Updated to False whenever any hit is found.
 
     @property
     def original_name(self) -> str:
@@ -187,16 +186,6 @@ class Query:
             f"which is out-of-bounds for any known NC start-end tuple: {self.non_coding_regions}"
             )
     
-    def mark_as_hit(self):
-        """
-        Confirm that this query has had a valid hit, and therefore, has some
-        sort of homology to something. 
-        
-        TODO: In the future, this could also be passed
-        coordinate information to mark some areas of the query identified compared
-        to other areas.
-        """
-        self.no_hits_warning = False
 
 @dataclass
 class QueryTranslation:

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -385,11 +385,11 @@ class QueryScreenStatus:
             self.screen_status = ScreenStatus.SKIP
             return
 
-        # If Taxonomy steps were skipped, and we passed, then update to skipped pass.
+        # If Taxonomy steps were skipped, but we passed, then --skip-tx or --skip-nt was used. 
+        # Update to skipped pass.
         if (self.screen_status == ScreenStatus.PASS and 
-                (self.protein_taxonomy == ScreenStatus.SKIP or 
-                self.nucleotide_taxonomy == ScreenStatus.SKIP)
-            ):
+            (self.protein_taxonomy == ScreenStatus.PASS_SKIP_TX or
+             self.nucleotide_taxonomy == ScreenStatus.PASS_SKIP_TX)):
             self.screen_status = ScreenStatus.PASS_SKIP_TX
             return
 
@@ -498,7 +498,7 @@ class QueryResult:
         logger.debug("Updating step status flags for query %s", self.query)
         logger.debug("Current status %s", self.status)
         
-        ignored_status = {ScreenStatus.SKIP, ScreenStatus.ERROR, ScreenStatus.PASS}
+        ignored_status = {ScreenStatus.PASS_SKIP_TX, ScreenStatus.SKIP, ScreenStatus.ERROR, ScreenStatus.PASS}
         
         if self.status.biorisk not in ignored_status:
             self.status.biorisk = ScreenStatus.NULL

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -289,9 +289,6 @@ class Rationale(StrEnum):
     TAX_WARN = " equally-good matches to regulated and non-regulated organisms"
 
     # Outcomes:
-    NO_HITS = ("No matches found during any stage of analysis. "
-                "Sequence risk is unknown, possibly generated in silico. ")
-    NO_HITS_SKIP_NOTE = NO_HITS + "Matches may be found if re-run without skipping steps."
     TOO_SHORT = "Query is too short, and was skipped."
 
     FLAG = " flags"
@@ -375,11 +372,6 @@ class QueryScreenStatus:
                                   self.nucleotide_taxonomy,
                                   self.low_concern}):
             self.screen_status = ScreenStatus.STOP
-            return
-
-        # If everything is happy, but we haven't hit anything, time to be suspicious...
-        if (self.screen_status == ScreenStatus.PASS and query_data.no_hits_warning):
-            self.screen_status = ScreenStatus.WARN
             return
 
         # If biorisk was skipped then it is skipped overall - likely query is too short...
@@ -578,20 +570,7 @@ class QueryResult:
             state.rationale = Rationale.INCOMPLETE
             return
 
-        # Handle no hits warnings
-        # --------------------------------------------------------------------
-        if (state.screen_status == ScreenStatus.WARN and
-            state.biorisk == ScreenStatus.PASS and
-            state.protein_taxonomy in [ScreenStatus.PASS, ScreenStatus.SKIP]  and
-            state.nucleotide_taxonomy in [ScreenStatus.PASS, ScreenStatus.SKIP] and
-            state.low_concern in [ScreenStatus.PASS, ScreenStatus.SKIP]):
-            # Add an extra caveat if the taxonomy search was skipped
-            if ScreenStatus.SKIP in [state.protein_taxonomy, state.nucleotide_taxonomy]:
-                state.rationale = Rationale.NO_HITS_SKIP_NOTE
-            else:
-                state.rationale = Rationale.NO_HITS
-            return
-
+ 
         # Handle simple passes
         # --------------------------------------------------------------------
         if state.screen_status == ScreenStatus.PASS:
@@ -687,8 +666,6 @@ class QueryResult:
         Updates the commec recommendation based on all hits recommendations.
         """
         
-        assert hasattr(query_data, "no_hits_warning")
-
         # A rare instance where we want our dictionary to be sorted
         sorted_items_desc = sorted(
             self.hits.items(), key=lambda item: item[1].get_e_value(), reverse=True

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -53,6 +53,7 @@ class ScreenStatus(StrEnum):
     NULL = "-"
     SKIP = "Skip"
     PASS = "Pass"
+    PASS_SKIP_TX = "Pass (Skipped Taxonomy)"
     CLEARED_WARN = "Warning (Cleared)"
     CLEARED_FLAG = "Flag (Cleared)"
     WARN = "Warning"
@@ -73,6 +74,9 @@ class ScreenStatus(StrEnum):
                 " skipping low-concern screen when there are no flags to clear)"
             ),
             ScreenStatus.PASS: "Query was not flagged in this screening step; biosecurity review may not be needed",
+            ScreenStatus.PASS_SKIP_TX: (
+                "Query was not flagged in this screening step; "
+                "biosecurity review may not be needed. However, the Taxonomy screening steps were skipped."),
             ScreenStatus.CLEARED_WARN: (
                 "Warning was cleared, since query region was identified as low-concern"
                 " (e.g. housekeeping gene, common synbio part)"),
@@ -96,12 +100,13 @@ class ScreenStatus(StrEnum):
             ScreenStatus.NULL: 0,
             ScreenStatus.SKIP: 1,
             ScreenStatus.PASS: 2,
-            ScreenStatus.CLEARED_WARN: 3,
-            ScreenStatus.CLEARED_FLAG: 4,
-            ScreenStatus.WARN: 5,
-            ScreenStatus.FLAG: 6,
-            ScreenStatus.STOP: 7,
-            ScreenStatus.ERROR: 8,
+            ScreenStatus.PASS_SKIP_TX: 3,
+            ScreenStatus.CLEARED_WARN: 4,
+            ScreenStatus.CLEARED_FLAG: 5,
+            ScreenStatus.WARN: 6,
+            ScreenStatus.FLAG: 7,
+            ScreenStatus.STOP: 8,
+            ScreenStatus.ERROR: 9,
         }
         return order[self]
 
@@ -297,6 +302,7 @@ class Rationale(StrEnum):
     CLEARED = " cleared as common or non-hazardous"
 
     INCOMPLETE = "Screening was not run to completion."
+    SKIPPED_TX = "Screening was run without Taxonomy steps."
 
 @dataclass
 class QueryScreenStatus:
@@ -377,6 +383,14 @@ class QueryScreenStatus:
         # If biorisk was skipped then it is skipped overall - likely query is too short...
         if (self.biorisk == ScreenStatus.SKIP):
             self.screen_status = ScreenStatus.SKIP
+            return
+
+        # If Taxonomy steps were skipped, and we passed, then update to skipped pass.
+        if (self.screen_status == ScreenStatus.PASS and 
+                (self.protein_taxonomy == ScreenStatus.SKIP or 
+                self.nucleotide_taxonomy == ScreenStatus.SKIP)
+            ):
+            self.screen_status = ScreenStatus.PASS_SKIP_TX
             return
 
 
@@ -575,6 +589,12 @@ class QueryResult:
         # --------------------------------------------------------------------
         if state.screen_status == ScreenStatus.PASS:
             state.rationale = Rationale.START_PASS + "."
+            return
+
+        # Handle simple passes - with --skip-tx or --skip-nt
+        # --------------------------------------------------------------------
+        if state.screen_status == ScreenStatus.PASS_SKIP_TX:
+            state.rationale = Rationale.START_PASS + ". However, " + Rationale.SKIPPED_TX
             return
 
         # Handle ONLY cleared outputs

--- a/commec/flag.py
+++ b/commec/flag.py
@@ -143,10 +143,11 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
         output_rationale = query.status.rationale if query.status.rationale != Rationale.NULL else ""
 
         overall_flag = query.status.screen_status
+        
+        # Updating overall flags when no hits are reported
         if query.status.rationale == Rationale.NO_HITS:
             overall_flag = "No Hits"
 
-        overall_flag = query.status.screen_status
         if query.status.rationale == Rationale.NO_HITS_SKIP_NOTE:
             overall_flag = "No Hits (skipped steps)"
 
@@ -183,10 +184,11 @@ def write_output_csv(output_dir: str | os.PathLike, status: dict, evalportal_for
     status_df = status_df.map(lambda x: ";".join(sorted(x)) if isinstance(x, set) else x)
 
     if evalportal_format:
-        # Using a "strict" mode coverting Flag/Warning to 1, and everything else to 0.
-        status_df["flag"] = status_df["flag"].map(
+        # Using a "strict" mode converting Flag/Warning to 1, and everything else to 0.
+        status_df["Flag"] = status_df["flag"].map(
             lambda x: 1 if x == "Flag" or x == "Warning" else 0)
-        status_df = status_df.rename(columns={"name": "UUID", "flag": "Flag"})
+        status_df = status_df.rename(columns={"name": "UUID"})
+        status_df = status_df[["UUID", "Flag"]]
 
     status_df.to_csv(status_file, index=False)
     print(f"Pipeline step status written to {status_file}")

--- a/commec/flag.py
+++ b/commec/flag.py
@@ -144,13 +144,6 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
 
         overall_flag = query.status.screen_status
         
-        # Updating overall flags when no hits are reported
-        if query.status.rationale == Rationale.NO_HITS:
-            overall_flag = "No Hits"
-
-        if query.status.rationale == Rationale.NO_HITS_SKIP_NOTE:
-            overall_flag = "No Hits (skipped steps)"
-
         results.append({
         "name": name,
         "filepath": file_path,

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -409,7 +409,7 @@ class Screen:
                 self.reset_query_statuses(ScreenStep.TAXONOMY_AA, ScreenStatus.ERROR)
         else:
             logger.info("SKIPPING STEP 2: Protein search")
-            self.reset_query_statuses(ScreenStep.TAXONOMY_AA, ScreenStatus.SKIP)
+            self.reset_query_statuses(ScreenStep.TAXONOMY_AA, ScreenStatus.PASS_SKIP_TX)
 
         # Taxonomy screen (Nucleotide)
         if self.params.should_do_nucleotide_screening:
@@ -426,7 +426,7 @@ class Screen:
                 self.reset_query_statuses(ScreenStep.TAXONOMY_NT, ScreenStatus.ERROR)
         else:
             logger.info("SKIPPING STEP 3: Nucleotide search")
-            self.reset_query_statuses(ScreenStep.TAXONOMY_NT, ScreenStatus.SKIP)
+            self.reset_query_statuses(ScreenStep.TAXONOMY_NT, ScreenStatus.PASS_SKIP_TX)
 
         # Benign Screen
         if self.params.should_do_low_concern_screening:

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -136,8 +136,6 @@ def parse_biorisk_hits(search_handler : HmmerHandler,
             logger.error("Query during hmmscan could not be found! [%s]", affected_query)
             continue
 
-        queries[affected_query[:-2]].mark_as_hit()
-
         # Grab a list of unique queries, and targets for iteration.
         unique_query_data : pd.DataFrame = hmmer[hmmer['query name'] == affected_query]
         unique_targets = unique_query_data['target name'].unique()

--- a/commec/screeners/check_low_concern.py
+++ b/commec/screeners/check_low_concern.py
@@ -287,7 +287,6 @@ def _update_low_concern_data_for_query(query : Query,
         for region in hit.ranges:
 
             if not low_concern_protein_for_query.empty:
-                query.mark_as_hit()
                 low_concern_proteins = _filter_low_concern_proteins(query, hit, region,
                                             low_concern_protein_for_query,
                                             low_concern_descriptions)
@@ -296,7 +295,6 @@ def _update_low_concern_data_for_query(query : Query,
                     new_low_concern_protein_hits.extend(low_concern_proteins)
             
             if not low_concern_rna_for_query.empty:
-                query.mark_as_hit()
                 low_concern_rna = _filter_low_concern_rna(query, hit, region,
                                        low_concern_rna_for_query)
                 if low_concern_rna:
@@ -304,7 +302,6 @@ def _update_low_concern_data_for_query(query : Query,
                     new_low_concern_rna_hits.extend(low_concern_rna)
                 
             if not low_concern_dna_for_query.empty:
-                query.mark_as_hit()
                 low_concern_dna = _filter_low_concern_dna(query, hit, region,
                                           low_concern_dna_for_query)
                 if low_concern_dna:

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -133,11 +133,9 @@ def parse_taxonomy_hits(
     for query_acc in unique_queries:
         query_obj = queries.get(query_acc)
         if query_obj:
-            logger.debug("Confirming hits for query %s.", query_acc)
-            query_obj.mark_as_hit()
+            logger.debug("Found hits for query %s.", query_acc)
         else:
-            logger.error("Could not mark query %s for confirmation of hit, "
-                            "query not found in input queries.", query_acc)
+            logger.error("Query %s not found in input queries.", query_acc)
 
     # Add taxonomic labels, and filter synthetic constructs
     blast = get_taxonomic_labels(blast, reg_taxids, vax_taxids, taxonomy_directory, n_threads)

--- a/commec/tests/test_data/flag_tests.json
+++ b/commec/tests/test_data/flag_tests.json
@@ -333,6 +333,34 @@
                     }
                 }
             }
+        },
+        "FLAG_TEST_07": {
+            "query": "FLAG_TEST_07",
+            "length": 1,
+            "status": {
+                "screen_status": "Warning",
+                "biorisk": "Pass",
+                "protein_taxonomy": "Pass",
+                "nucleotide_taxonomy": "Pass",
+                "low_concern": "Pass",
+                "rationale": "No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. "
+            },
+            "hits": {
+            }
+        },
+        "FLAG_TEST_08": {
+            "query": "FLAG_TEST_08",
+            "length": 1,
+            "status": {
+                "screen_status": "Warning",
+                "biorisk": "Pass",
+                "protein_taxonomy": "Skip",
+                "nucleotide_taxonomy": "Skip",
+                "low_concern": "Pass",
+                "rationale": "No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. Matches may be found if re-run without skipping steps."
+            },
+            "hits": {
+            }
         }
     }
 }

--- a/commec/tests/test_data/flag_tests.json
+++ b/commec/tests/test_data/flag_tests.json
@@ -338,12 +338,11 @@
             "query": "FLAG_TEST_07",
             "length": 1,
             "status": {
-                "screen_status": "Warning",
+                "screen_status": "Pass",
                 "biorisk": "Pass",
                 "protein_taxonomy": "Pass",
                 "nucleotide_taxonomy": "Pass",
-                "low_concern": "Pass",
-                "rationale": "No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. "
+                "low_concern": "Pass"
             },
             "hits": {
             }
@@ -352,12 +351,11 @@
             "query": "FLAG_TEST_08",
             "length": 1,
             "status": {
-                "screen_status": "Warning",
+                "screen_status": "Pass",
                 "biorisk": "Pass",
                 "protein_taxonomy": "Skip",
                 "nucleotide_taxonomy": "Skip",
-                "low_concern": "Pass",
-                "rationale": "No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. Matches may be found if re-run without skipping steps."
+                "low_concern": "Pass"
             },
             "hits": {
             }

--- a/commec/tests/test_flag.py
+++ b/commec/tests/test_flag.py
@@ -26,6 +26,8 @@ def test_flag(tmp_path):
         FLAG_TEST_04,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
         FLAG_TEST_05,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
         FLAG_TEST_06,{SCREEN_DIR}/flag_tests.json,Pass,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
+        FLAG_TEST_07,{SCREEN_DIR}/flag_tests.json,No Hits,Pass,Pass,Pass,Pass,False,False,False,False,False,False,"No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. "
+        FLAG_TEST_08,{SCREEN_DIR}/flag_tests.json,No Hits (skipped steps),Pass,Skip,Skip,Pass,False,False,False,False,False,False,"No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. Matches may be found if re-run without skipping steps."
         FCTEST1,{SCREEN_DIR}/functional.json,Flag,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
         """
     )
@@ -45,15 +47,17 @@ def test_evalportal_format(tmp_path):
     assert status_output.exists()
 
     expected_status = textwrap.dedent(
-        f"""\
-        UUID,filepath,Flag,biorisk,protein,nucleotide,low_concern,virus_flag,bacteria_flag,eukaryote_flag,low_concern_protein,low_concern_rna,low_concern_dna,rationale
-        FLAG_TEST_01,{SCREEN_DIR}/flag_tests.json,1,Flag,Pass,Pass,Flag,False,False,False,False,False,False,
-        FLAG_TEST_02,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,True,False,False,False,False,False,
-        FLAG_TEST_03,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,True,False,False,False,False,
-        FLAG_TEST_04,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
-        FLAG_TEST_05,{SCREEN_DIR}/flag_tests.json,1,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
-        FLAG_TEST_06,{SCREEN_DIR}/flag_tests.json,0,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
-        FCTEST1,{SCREEN_DIR}/functional.json,1,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
+        """\
+        UUID,Flag
+        FLAG_TEST_01,1
+        FLAG_TEST_02,1
+        FLAG_TEST_03,1
+        FLAG_TEST_04,1
+        FLAG_TEST_05,1
+        FLAG_TEST_06,0
+        FLAG_TEST_07,0
+        FLAG_TEST_08,0
+        FCTEST1,1
         """
     )
     actual_status = status_output.read_text()

--- a/commec/tests/test_flag.py
+++ b/commec/tests/test_flag.py
@@ -26,8 +26,8 @@ def test_flag(tmp_path):
         FLAG_TEST_04,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
         FLAG_TEST_05,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
         FLAG_TEST_06,{SCREEN_DIR}/flag_tests.json,Pass,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
-        FLAG_TEST_07,{SCREEN_DIR}/flag_tests.json,No Hits,Pass,Pass,Pass,Pass,False,False,False,False,False,False,"No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. "
-        FLAG_TEST_08,{SCREEN_DIR}/flag_tests.json,No Hits (skipped steps),Pass,Skip,Skip,Pass,False,False,False,False,False,False,"No matches found during any stage of analysis. Sequence risk is unknown, possibly generated in silico. Matches may be found if re-run without skipping steps."
+        FLAG_TEST_07,{SCREEN_DIR}/flag_tests.json,Pass,Pass,Pass,Pass,Pass,False,False,False,False,False,False,
+        FLAG_TEST_08,{SCREEN_DIR}/flag_tests.json,Pass,Pass,Skip,Skip,Pass,False,False,False,False,False,False,
         FCTEST1,{SCREEN_DIR}/functional.json,Flag,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
         """
     )

--- a/commec/tests/test_rationales.py
+++ b/commec/tests/test_rationales.py
@@ -17,5 +17,5 @@ def test_hmmer(tmp_path):
     screen_test.add_query("query1",1200)
     screen_test.add_hit(ScreenStep.BIORISK, "query1", 100, 200, "HighEvalueHit", "HEH", 500, regulated=True, evalue = 100.0)
     result = screen_test.run("--skip-tx")
-    assert result.queries["query1"].status.screen_status == ScreenStatus.PASS
-    assert result.queries["query1"].status.rationale == str(Rationale.START_PASS + ".")
+    assert result.queries["query1"].status.screen_status == ScreenStatus.PASS_SKIP_TX
+    assert result.queries["query1"].status.rationale == str(Rationale.START_PASS + ". However, " + Rationale.SKIPPED_TX)

--- a/commec/tests/test_rationales.py
+++ b/commec/tests/test_rationales.py
@@ -11,13 +11,11 @@ from commec.config.result import ScreenStatus, Rationale
 def test_hmmer(tmp_path):
     """
     When there are hits to Biorisk with a large E-value, but no other hits, and we 
-     are running in the skip taxonomy mode, we correctly label the outcome
-     as warning, however the rationale is set to "Matches to ." instead of
-     the correct Rationale text indicating no hits.
+     are running in the skip taxonomy mode, we label the outcome and rationale to PASS.
     """
     screen_test = ScreenTesterFactory("low_evalue_hmmer", tmp_path)
     screen_test.add_query("query1",1200)
     screen_test.add_hit(ScreenStep.BIORISK, "query1", 100, 200, "HighEvalueHit", "HEH", 500, regulated=True, evalue = 100.0)
     result = screen_test.run("--skip-tx")
-    assert result.queries["query1"].status.screen_status == ScreenStatus.WARN
-    assert result.queries["query1"].status.rationale == str(Rationale.NO_HITS_SKIP_NOTE)
+    assert result.queries["query1"].status.screen_status == ScreenStatus.PASS
+    assert result.queries["query1"].status.rationale == str(Rationale.START_PASS + ".")

--- a/commec/tests/test_screen.py
+++ b/commec/tests/test_screen.py
@@ -131,3 +131,17 @@ def test_different_regions(tmp_path):
                             " `query1` not equal to expected number (5).")
     assert status == ScreenStatus.FLAG, ("Expected status is to FLAG, current status"
                                         f" is {status}, likely multiple region clearing issue.")
+
+def test_no_hits_outcomes(tmp_path):
+    """
+    Simply tests what occurs when commec is run and finds no hits, with and without --skip-tx
+    """
+    screen_test = ScreenTesterFactory("no_hits_test", tmp_path)
+    screen_test.add_query("query_not_hits",1000)
+    result = screen_test.run()
+    assert result.queries["query_not_hits"].status.screen_status == ScreenStatus.PASS
+
+    screen_test_skip_tx = ScreenTesterFactory("no_hits_test_skip_tx", tmp_path)
+    screen_test_skip_tx.add_query("query_not_hits",1000)
+    result = screen_test_skip_tx.run("--skip-tx")
+    assert result.queries["query_not_hits"].status.screen_status == ScreenStatus.PASS_SKIP_TX

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python>=3.10
+  - python>=3.10,<3.14
   # Runtime Python dependencies
   - biopython
   - numpy


### PR DESCRIPTION
## Background
The custom BLAST databases significantly increase the fraction of queries with no hits to the database due to the restricted taxonomic scope around the controlled taxids. Therefore, the "No-Hits Warning" doesn't exclusively signify the in-silico design of the query anymore. This PR removes the no-hits warning logic and makes some other minor changes required for the benchmarking pipeline.

## Changes
### Breaking changes
* Removed the warning and rationale for queries with "No Hits" and "No Hits (Skipped)". Queries with no hits to the database are now passed as no regions of concern.
### Minor changes
* Removed unused columns in the evalportal format for simplification
* Restricted the Python version to <3.14 for compatibility with Snakemake in the benchmarking pipeline

## Testing
Tested the changes on a small benchmarking test set. The comparison of flags before and after the changes shows all queries with no hits being passed:
<img width="374" height="132" alt="image" src="https://github.com/user-attachments/assets/d7347be7-51a5-45f8-8f68-92620f15da41" />

Before: 
<img width="903" height="223" alt="image" src="https://github.com/user-attachments/assets/4fd67a8e-1f81-48da-983b-7e260640c4ce" />

After: 
<img width="896" height="216" alt="image" src="https://github.com/user-attachments/assets/b39b6683-6520-4e81-9d24-522086f77a5a" />
