### PR TITLE
Low Concern Bugfix

### DIFF
--- a/commec/screeners/check_low_concern.py
+++ b/commec/screeners/check_low_concern.py
@@ -81,13 +81,13 @@ def _filter_low_concern_proteins(query : Query,
         return []
 
     # Report top hit for Protein / RNA / Synbio
-    low_concern_hit = low_concern_protein_for_query_trimmed["subject title"][0]
+    low_concern_hit = low_concern_protein_for_query_trimmed["subject title"].iloc[0]
     low_concern_hit_description = str(*low_concern_descriptions["Description"][low_concern_descriptions["ID"] == low_concern_hit])
     match_ranges = [
         MatchRange(
-        float(low_concern_protein_for_query_trimmed['evalue'][0]),
-        int(low_concern_protein_for_query_trimmed['s. start'][0]), int(low_concern_protein_for_query_trimmed['s. end'][0]),
-        int(low_concern_protein_for_query_trimmed['q. start'][0]), int(low_concern_protein_for_query_trimmed['q. end'][0])
+        float(low_concern_protein_for_query_trimmed['evalue'].iloc[0]),
+        int(low_concern_protein_for_query_trimmed['s. start'].iloc[0]), int(low_concern_protein_for_query_trimmed['s. end'].iloc[0]),
+        int(low_concern_protein_for_query_trimmed['q. start'].iloc[0]), int(low_concern_protein_for_query_trimmed['q. end'].iloc[0])
         )
     ]
     low_concern_hit_outcome = HitResult(
@@ -98,7 +98,7 @@ def _filter_low_concern_proteins(query : Query,
             low_concern_hit,
             low_concern_hit_description,
             match_ranges,
-            annotations={"Coverage: ":float(low_concern_protein_for_query_trimmed['coverage_ratio'][0])}
+            annotations={"Coverage: ":float(low_concern_protein_for_query_trimmed['coverage_ratio'].iloc[0])}
         )
 
     # Rarely, something can be cleared that is already cleared, no need to report on that.
@@ -137,13 +137,13 @@ def _filter_low_concern_rna(query : Query,
                 low_concern_rna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head())
     
     if not low_concern_rna_for_query_passed.empty:
-        low_concern_hit = low_concern_rna_for_query_trimmed["subject title"][0]
-        low_concern_hit_description =  low_concern_rna_for_query_trimmed["description of target"][0]
+        low_concern_hit = low_concern_rna_for_query_trimmed["subject title"].iloc[0]
+        low_concern_hit_description =  low_concern_rna_for_query_trimmed["description of target"].iloc[0]
         match_ranges = [
             MatchRange(
-            float(low_concern_rna_for_query_trimmed['evalue'][0]),
-            int(low_concern_rna_for_query_trimmed['s. start'][0]), int(low_concern_rna_for_query_trimmed['s. end'][0]),
-            int(low_concern_rna_for_query_trimmed['q. start'][0]), int(low_concern_rna_for_query_trimmed['q. end'][0])
+            float(low_concern_rna_for_query_trimmed['evalue'].iloc[0]),
+            int(low_concern_rna_for_query_trimmed['s. start'].iloc[0]), int(low_concern_rna_for_query_trimmed['s. end'].iloc[0]),
+            int(low_concern_rna_for_query_trimmed['q. start'].iloc[0]), int(low_concern_rna_for_query_trimmed['q. end'].iloc[0])
             )
         ]
         low_concern_hit_outcome = HitResult(
@@ -198,13 +198,13 @@ def _filter_low_concern_dna(query : Query,
                         hit.name, region.query_start, region.query_end)
         return []
 
-    low_concern_hit = low_concern_dna_for_query_trimmed["subject title"][0]
-    low_concern_hit_description =  low_concern_dna_for_query_trimmed["subject title"][0]
+    low_concern_hit = low_concern_dna_for_query_trimmed["subject title"].iloc[0]
+    low_concern_hit_description =  low_concern_dna_for_query_trimmed["subject title"].iloc[0]
     match_ranges = [
         MatchRange(
-        float(low_concern_dna_for_query_trimmed['evalue'][0]),
-        int(low_concern_dna_for_query_trimmed['s. start'][0]), int(low_concern_dna_for_query_trimmed['s. end'][0]),
-        int(low_concern_dna_for_query_trimmed['q. start'][0]), int(low_concern_dna_for_query_trimmed['q. end'][0])
+        float(low_concern_dna_for_query_trimmed['evalue'].iloc[0]),
+        int(low_concern_dna_for_query_trimmed['s. start'].iloc[0]), int(low_concern_dna_for_query_trimmed['s. end'].iloc[0]),
+        int(low_concern_dna_for_query_trimmed['q. start'].iloc[0]), int(low_concern_dna_for_query_trimmed['q. end'].iloc[0])
         )
     ]
     low_concern_hit_outcome = HitResult(

--- a/commec/tests/screen_factory.py
+++ b/commec/tests/screen_factory.py
@@ -231,8 +231,10 @@ class ScreenTesterFactory:
         self.input_fasta_path = self.tmp_path / f"{self.name}.fasta"
         print("Using fasta file: " + str(self.input_fasta_path))
 
+        query_fasta = ""
         for key, value in self.queries.items():
-            self.input_fasta_path.write_text(f">{key}\n{value}\n")
+            query_fasta = query_fasta + f">{key}\n{value}\n"
+        self.input_fasta_path.write_text(query_fasta)
 
         # --RESUME FILES::
         # BIORISK FILES

--- a/commec/tests/test_screen.py
+++ b/commec/tests/test_screen.py
@@ -104,6 +104,27 @@ def test_screen_factory(tmp_path):
     assert result.queries["query_01"].status.nucleotide_taxonomy == ScreenStatus.FLAG
     assert result.queries["query_01"].status.low_concern == ScreenStatus.FLAG
 
+def test_low_concern_multiquery(tmp_path):
+    """
+    Checks that the low concern hits are correctly accessed when multiple queries are used, and 
+    the low concern databases have multiple hits across all queries.
+    """
+    screen_test = ScreenTesterFactory("lowconcern_multiquerycheck", tmp_path)
+    screen_test.add_query("query1", 1000)
+    screen_test.add_query("query2", 1000)
+    screen_test.add_query("query3", 1000)
+    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 400, 600, "ClearMe", "RR55", 500, regulated=True)
+    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query2", 400, 600, "ClearMe", "RR55", 500, regulated=True)
+    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query3", 400, 600, "ClearMe", "RR55", 500, regulated=True)
+    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query1", 100, 900, "ClearProtein", "RR55CLEAR", 500)
+    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query2", 100, 900, "ClearProtein", "RR55CLEAR", 500)
+    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query3", 100, 900, "ClearProtein", "RR55CLEAR", 500)
+    result = screen_test.run()
+
+    assert result.queries["query1"].status.screen_status == ScreenStatus.CLEARED_FLAG
+    assert result.queries["query2"].status.screen_status == ScreenStatus.CLEARED_FLAG
+    assert result.queries["query3"].status.screen_status == ScreenStatus.CLEARED_FLAG
+
 def test_different_regions(tmp_path):
     """
     Creates a single hit, with many regions, then a single clear on one of those regions.


### PR DESCRIPTION
## Background
Manu came across a critical error in commec screen when testing 100 queries for the upcoming biorisk database release. One of the queries (the final one - although this coincidental) failed an index accession operation for the RNA low concern database after filtering. Interestingly, the bug disappeared when the query is run in isolation.
Further investigations by limiting to the 3 queries present in the RNA low concern outputs revealed that the accession logic on that database for grabbing the top remaining low concern hit was incorrect, accessing the 0th index by name rather than location.

This bug affects non-first queries in multi-query only commec screen runs where the benign steps find multiple outputs such that the index of the affect queries row is not 0.

This was identified on the RNA low concern step, however could also occur in the other low concern steps as well - which share the logic of accession with `[0]`.

## Changes
All low concern steps are now accessed using `iloc[0]`, rather than `[0]`, which ensures the 0th element of the remaining truncated benign data (i.e. the topmost, truncated benign hit) is reported on. 

### Bug fixes
commec screen no longer crashes in multi-query runs where a two or more queries have benign hits.