### PR TITLE
Release v1.0.4

### DIFF
--- a/commec/config/constants.py
+++ b/commec/config/constants.py
@@ -4,6 +4,14 @@
 # SCREENING
 MINIMUM_QUERY_LENGTH = 41
 
+# BIORISK E-VALUE FILTERING
+# Sequences shorter than this threshold use a length-dependent E-value cutoff.
+BIORISK_SHORT_QUERY_NT_THRESHOLD = 200
+# Exponent for the length-dependent E-value formula: E < 1 / (1 + L^EXPONENT)
+BIORISK_SHORT_QUERY_EVALUE_EXPONENT = 2.598
+# E-value cutoff applied to sequences at or above the length threshold.
+BIORISK_LONG_QUERY_EVALUE_THRESHOLD = 1e-20
+
 # I/O
 DEFAULT_CONFIG_YAML_PATH = "screen-default-config.yaml"
 MAXIMUM_FILENAME_SIZE = 255

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -150,9 +150,9 @@ class ScreenStep(StrEnum):
     BIORISK = "Biorisk Search"
     TAXONOMY_NT = "Nucleotide Taxonomy Search"
     TAXONOMY_AA = "Protein Taxonomy Search"
-    LOW_CONCERN_PROTEIN = "Benign Protein Search"
-    LOW_CONCERN_RNA = "Benign RNA Search"
-    LOW_CONCERN_DNA = "Benign DNA Search"
+    LOW_CONCERN_PROTEIN = "Low Concern Protein Search"
+    LOW_CONCERN_RNA = "Low Concern RNA Search"
+    LOW_CONCERN_DNA = "Low Concern DNA Search"
 
 
 @dataclass

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -251,38 +251,41 @@ class ScreenIO:
         This script will update the dictionary to propagate these substitutions.
         If a database directory is provided, it will override the base_path provided in the yaml.
         """
-        if self.config.get("base_paths"):
-            try:
-                base_paths = self.config["base_paths"]
-                if db_dir_override is not None:
-                    logger.debug(f"Command line arguments updated base databases directory: {db_dir_override}")
-                    base_paths["default"] = db_dir_override
-                else:
-                    self.db_dir = base_paths["default"]
+        def recursive_format(nested_yaml, base_paths):
+            """
+            Recursively apply string formatting to read paths from nested yaml config dicts.
+            """
+            if isinstance(nested_yaml, dict):
+                return {key : recursive_format(value, base_paths) 
+                        for key, value in nested_yaml.items()}
+            if isinstance(nested_yaml, str):
+                try:
+                    return nested_yaml.format(**base_paths)
+                except KeyError as e:
+                    raise ValueError(
+                        f"Unknown base path key referenced in path: {nested_yaml}"
+                    ) from e
+            return nested_yaml
+            
+        try:
+            # Restores legacy behaviour with -d in commec screen CLI, with no yaml.
+            if db_dir_override is not None:
+                logger.debug("Command line arguments updated base databases directory: %s", db_dir_override)
+                self.config["base_paths"]["default"] = db_dir_override
+            else:
+                self.db_dir = self.config["base_paths"]["default"]
 
-                # Ensure all the base paths end with a separator
-                for key, value in base_paths.items():
-                    base_paths[key] = os.path.join(value,'')
+            # Ensure all the base paths end with a separator
+            for key, value in self.config["base_paths"].items():
+                self.config["base_paths"][key] = os.path.join(value,'')
+            
+            # Recursively format all paths
+            self.config["base_paths"] = recursive_format(self.config["base_paths"], self.config["base_paths"])
+            self.config = recursive_format(self.config, self.config["base_paths"])
 
-                def recursive_format(nested_yaml, base_paths):
-                    """
-                    Recursively apply string formatting to read paths from nested yaml config dicts.
-                    """
-                    if isinstance(nested_yaml, dict):
-                        return {key : recursive_format(value, base_paths) 
-                                for key, value in nested_yaml.items()}
-                    if isinstance(nested_yaml, str):
-                        try:
-                            return nested_yaml.format(**base_paths)
-                        except KeyError as e:
-                            raise ValueError(
-                                f"Unknown base path key referenced in path: {nested_yaml}"
-                            ) from e
-                    return nested_yaml
-
-                self.config = recursive_format(self.config, base_paths)
-            except TypeError:
-                pass
+        except TypeError as e:
+            logger.error("Encountered unexpected TypeError during yaml config base path substitution: %s", e)
+            pass
 
     @staticmethod
     def _get_output_prefixes(input_file: str | os.PathLike, prefix_arg=None) -> str:

--- a/commec/screen-default-config.yaml
+++ b/commec/screen-default-config.yaml
@@ -14,11 +14,11 @@ databases:
     path: '{default}nt_blast/core_nt'
   low_concern:
     rna:
-      path: '{default}low_concern/rna/benign.cm'
+      path: '{default}low_concern/rna/low_concern.cm'
     dna:
-      path: '{default}low_concern/dna/benign.fasta'
+      path: '{default}low_concern/dna/low_concern.fasta'
     protein:
-      path: '{default}low_concern/protein/benign.hmm'
+      path: '{default}low_concern/protein/low_concern.hmm'
     taxids: "{default}low_concern/vax_taxids.txt"
     annotations: '{default}low_concern/low_concern_annotations.tsv'
   taxonomy:

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -10,6 +10,11 @@ import logging
 import os
 import pandas as pd
 from commec.config.query import Query
+from commec.config.constants import (
+    BIORISK_SHORT_QUERY_NT_THRESHOLD,
+    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
+    BIORISK_LONG_QUERY_EVALUE_THRESHOLD,
+)
 from commec.tools.hmmer import (
     readhmmer,
     remove_overlaps,
@@ -64,6 +69,30 @@ def read_biorisk_annotations(hmm_folder_csv) -> pd.DataFrame:
     lookup.fillna(False, inplace=True)
     return lookup
 
+def biorisk_evalue_filter(hmmer: pd.DataFrame) -> pd.DataFrame:
+    """
+    Filter hmmscan hits by E-value, using a length-dependent threshold for short queries.
+
+    For queries shorter than BIORISK_SHORT_QUERY_NT_THRESHOLD nucleotides, the cutoff is:
+        E-value < 1 / (1 + nt_qlen ^ BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+    For all other queries the cutoff is BIORISK_LONG_QUERY_EVALUE_THRESHOLD.
+
+    Expects numeric 'E-value' and 'nt_qlen' columns; coerces them if needed.
+    Returns a filtered copy of the input DataFrame.
+    """
+    df = hmmer.copy()
+    df['E-value'] = pd.to_numeric(df['E-value'], errors='coerce')
+    df['nt_qlen'] = pd.to_numeric(df['nt_qlen'], errors='coerce')
+
+    short_query = df['nt_qlen'] < BIORISK_SHORT_QUERY_NT_THRESHOLD
+    short_cutoff = 1 / (1 + df['nt_qlen'] ** BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+
+    mask = (short_query & (df['E-value'] < short_cutoff)) | \
+           (~short_query & (df['E-value'] < BIORISK_LONG_QUERY_EVALUE_THRESHOLD))
+
+    return df[mask]
+
+
 def parse_biorisk_hits(search_handler : HmmerHandler,
                                       biorisk_annotations_file : str | os.PathLike,
                                       data : ScreenResult,
@@ -100,13 +129,12 @@ def parse_biorisk_hits(search_handler : HmmerHandler,
     # Read in Output, and parse.
     hmmer : pd.DataFrame = readhmmer(search_handler.out_file)
     logger.debug("Biorisk Import: shape: %s preview:\n%s", hmmer.shape, hmmer.head())
-    keep1 = [i for i, x in enumerate(hmmer['E-value']) if x < 1e-20]
-    hmmer = hmmer.iloc[keep1,:]
-    logger.debug("Biorisk Filterd by E-Value: shape: %s preview:\n%s", 
-                 hmmer.shape, hmmer.head())
     append_nt_querylength_info(hmmer, queries)
     logger.debug("Appended Query NT length: shape: %s preview:\n%s", 
                  hmmer.shape, hmmer[["query name","nt_qlen"]].head())
+    hmmer = biorisk_evalue_filter(hmmer)
+    logger.debug("Biorisk Filterd by E-Value: shape: %s preview:\n%s", 
+                 hmmer.shape, hmmer.head())
     recalculate_hmmer_query_coordinates(hmmer)
     logger.debug("Recalculated AA to NT coords: shape: %s preview:\n%s", 
                  hmmer.shape, hmmer[["ali from","ali to","q. start","q. end"]].head())

--- a/commec/screeners/check_low_concern.py
+++ b/commec/screeners/check_low_concern.py
@@ -81,13 +81,13 @@ def _filter_low_concern_proteins(query : Query,
         return []
 
     # Report top hit for Protein / RNA / Synbio
-    low_concern_hit = low_concern_protein_for_query_trimmed["subject title"][0]
+    low_concern_hit = low_concern_protein_for_query_trimmed["subject title"].iloc[0]
     low_concern_hit_description = str(*low_concern_descriptions["Description"][low_concern_descriptions["ID"] == low_concern_hit])
     match_ranges = [
         MatchRange(
-        float(low_concern_protein_for_query_trimmed['evalue'][0]),
-        int(low_concern_protein_for_query_trimmed['s. start'][0]), int(low_concern_protein_for_query_trimmed['s. end'][0]),
-        int(low_concern_protein_for_query_trimmed['q. start'][0]), int(low_concern_protein_for_query_trimmed['q. end'][0])
+        float(low_concern_protein_for_query_trimmed['evalue'].iloc[0]),
+        int(low_concern_protein_for_query_trimmed['s. start'].iloc[0]), int(low_concern_protein_for_query_trimmed['s. end'].iloc[0]),
+        int(low_concern_protein_for_query_trimmed['q. start'].iloc[0]), int(low_concern_protein_for_query_trimmed['q. end'].iloc[0])
         )
     ]
     low_concern_hit_outcome = HitResult(
@@ -98,7 +98,7 @@ def _filter_low_concern_proteins(query : Query,
             low_concern_hit,
             low_concern_hit_description,
             match_ranges,
-            annotations={"Coverage: ":float(low_concern_protein_for_query_trimmed['coverage_ratio'][0])}
+            annotations={"Coverage: ":float(low_concern_protein_for_query_trimmed['coverage_ratio'].iloc[0])}
         )
 
     # Rarely, something can be cleared that is already cleared, no need to report on that.
@@ -137,13 +137,13 @@ def _filter_low_concern_rna(query : Query,
                 low_concern_rna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head())
     
     if not low_concern_rna_for_query_passed.empty:
-        low_concern_hit = low_concern_rna_for_query_trimmed["subject title"][0]
-        low_concern_hit_description =  low_concern_rna_for_query_trimmed["description of target"][0]
+        low_concern_hit = low_concern_rna_for_query_trimmed["subject title"].iloc[0]
+        low_concern_hit_description =  low_concern_rna_for_query_trimmed["description of target"].iloc[0]
         match_ranges = [
             MatchRange(
-            float(low_concern_rna_for_query_trimmed['evalue'][0]),
-            int(low_concern_rna_for_query_trimmed['s. start'][0]), int(low_concern_rna_for_query_trimmed['s. end'][0]),
-            int(low_concern_rna_for_query_trimmed['q. start'][0]), int(low_concern_rna_for_query_trimmed['q. end'][0])
+            float(low_concern_rna_for_query_trimmed['evalue'].iloc[0]),
+            int(low_concern_rna_for_query_trimmed['s. start'].iloc[0]), int(low_concern_rna_for_query_trimmed['s. end'].iloc[0]),
+            int(low_concern_rna_for_query_trimmed['q. start'].iloc[0]), int(low_concern_rna_for_query_trimmed['q. end'].iloc[0])
             )
         ]
         low_concern_hit_outcome = HitResult(
@@ -198,13 +198,13 @@ def _filter_low_concern_dna(query : Query,
                         hit.name, region.query_start, region.query_end)
         return []
 
-    low_concern_hit = low_concern_dna_for_query_trimmed["subject title"][0]
-    low_concern_hit_description =  low_concern_dna_for_query_trimmed["subject title"][0]
+    low_concern_hit = low_concern_dna_for_query_trimmed["subject title"].iloc[0]
+    low_concern_hit_description =  low_concern_dna_for_query_trimmed["subject title"].iloc[0]
     match_ranges = [
         MatchRange(
-        float(low_concern_dna_for_query_trimmed['evalue'][0]),
-        int(low_concern_dna_for_query_trimmed['s. start'][0]), int(low_concern_dna_for_query_trimmed['s. end'][0]),
-        int(low_concern_dna_for_query_trimmed['q. start'][0]), int(low_concern_dna_for_query_trimmed['q. end'][0])
+        float(low_concern_dna_for_query_trimmed['evalue'].iloc[0]),
+        int(low_concern_dna_for_query_trimmed['s. start'].iloc[0]), int(low_concern_dna_for_query_trimmed['s. end'].iloc[0]),
+        int(low_concern_dna_for_query_trimmed['q. start'].iloc[0]), int(low_concern_dna_for_query_trimmed['q. end'].iloc[0])
         )
     ]
     low_concern_hit_outcome = HitResult(

--- a/commec/tests/screen_factory.py
+++ b/commec/tests/screen_factory.py
@@ -231,8 +231,10 @@ class ScreenTesterFactory:
         self.input_fasta_path = self.tmp_path / f"{self.name}.fasta"
         print("Using fasta file: " + str(self.input_fasta_path))
 
+        query_fasta = ""
         for key, value in self.queries.items():
-            self.input_fasta_path.write_text(f">{key}\n{value}\n")
+            query_fasta = query_fasta + f">{key}\n{value}\n"
+        self.input_fasta_path.write_text(query_fasta)
 
         # --RESUME FILES::
         # BIORISK FILES

--- a/commec/tests/test_check_biorisk.py
+++ b/commec/tests/test_check_biorisk.py
@@ -4,9 +4,14 @@ import pandas as pd
 import os
 from Bio.SeqRecord import SeqRecord, Seq
 
-from commec.screeners.check_biorisk import parse_biorisk_hits, HmmerHandler
+from commec.screeners.check_biorisk import biorisk_evalue_filter, parse_biorisk_hits, HmmerHandler
 from commec.config.result import ScreenResult
 from commec.config.query import Query
+from commec.config.constants import (
+    BIORISK_SHORT_QUERY_NT_THRESHOLD,
+    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
+    BIORISK_LONG_QUERY_EVALUE_THRESHOLD,
+)
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
@@ -58,3 +63,130 @@ def test_check_biorisk_return_codes(annotations_exists, has_empty_output, has_hi
 
         # Check the result
         assert result == expected_return
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_hmmer(nt_qlen: int, evalue: float) -> pd.DataFrame:
+    """Return a minimal single-row hmmscan DataFrame."""
+    return pd.DataFrame({"E-value": [evalue], "nt_qlen": [nt_qlen]})
+
+
+def _short_cutoff(nt_qlen: float) -> float:
+    """Length-dependent E-value cutoff for short queries."""
+    return 1 / (1 + nt_qlen ** BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+
+
+# ---------------------------------------------------------------------------
+# biorisk_evalue_filter — short-query regime (nt_qlen < threshold)
+# ---------------------------------------------------------------------------
+
+class TestBioriskEvalueFilterShortQuery:
+    """nt_qlen below BIORISK_SHORT_QUERY_NT_THRESHOLD uses the power-law cutoff."""
+
+    def test_short_query_passes_when_evalue_below_cutoff(self):
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 0.5  # clearly below cutoff
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 1
+
+    def test_short_query_filtered_when_evalue_above_cutoff(self):
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 2.0  # clearly above cutoff
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 0
+
+    def test_very_short_query_uses_power_law_not_long_threshold(self):
+        """A very short query with E-value below long threshold but above short
+        cutoff should be filtered out — not admitted by the long-query rule."""
+        nt_qlen = 10
+        # For nt_qlen=10 the short cutoff is ~1/(1+10^2.598) ≈ 2.5e-3; use a
+        # value that is below 1e-20 (long threshold) but above short cutoff.
+        # That is impossible to construct, so instead confirm the short rule
+        # dominates: use an evalue above the short cutoff and verify it is dropped.
+        evalue = _short_cutoff(nt_qlen) * 2
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 0
+
+    def test_query_just_below_threshold_uses_short_rule(self):
+        nt_qlen = BIORISK_SHORT_QUERY_NT_THRESHOLD - 1
+        evalue = _short_cutoff(nt_qlen) * 0.5
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 1
+
+class TestBioriskEvalueFilterLongQuery:
+    """nt_qlen at or above BIORISK_SHORT_QUERY_NT_THRESHOLD uses the fixed cutoff."""
+
+    def test_long_query_passes_when_evalue_below_threshold(self):
+        nt_qlen = BIORISK_SHORT_QUERY_NT_THRESHOLD
+        evalue = BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 0.1
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 1
+
+    def test_long_query_filtered_when_evalue_above_threshold(self):
+        nt_qlen = BIORISK_SHORT_QUERY_NT_THRESHOLD
+        evalue = BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 10
+        result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
+        assert len(result) == 0
+
+class TestBioriskEvalueFilterMultiRow:
+    """Tests covering mixed DataFrames and edge cases."""
+
+    def test_mixed_rows_only_passing_rows_retained(self):
+        nt_qlen_short = 100
+        nt_qlen_long = 500
+        df = pd.DataFrame({
+            "E-value": [
+                _short_cutoff(nt_qlen_short) * 0.5,   # short, passes
+                _short_cutoff(nt_qlen_short) * 2.0,   # short, filtered
+                BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 0.1,  # long, passes
+                BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 10,   # long, filtered
+            ],
+            "nt_qlen": [nt_qlen_short, nt_qlen_short, nt_qlen_long, nt_qlen_long],
+        })
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 2
+
+    def test_empty_dataframe_returns_empty(self):
+        df = pd.DataFrame({"E-value": [], "nt_qlen": []})
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 0
+
+    def test_string_columns_are_coerced_to_numeric(self):
+        """readhmmer returns string columns; filter must coerce them."""
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 0.5
+        df = pd.DataFrame({"E-value": [str(evalue)], "nt_qlen": [str(nt_qlen)]})
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 1
+
+    def test_non_numeric_evalues_are_dropped(self):
+        """Rows with non-coercible E-values become NaN and should be excluded."""
+        df = pd.DataFrame({"E-value": ["not_a_number"], "nt_qlen": [100]})
+        result = biorisk_evalue_filter(df)
+        assert len(result) == 0
+
+    def test_input_dataframe_is_not_mutated(self):
+        """The function must return a copy; the original dtypes must be unchanged."""
+        df = pd.DataFrame({"E-value": ["1e-25"], "nt_qlen": ["500"]})
+        original_dtype_evalue = df["E-value"].dtype
+        original_dtype_qlen = df["nt_qlen"].dtype
+        _ = biorisk_evalue_filter(df)
+        assert df["E-value"].dtype == original_dtype_evalue
+        assert df["nt_qlen"].dtype == original_dtype_qlen
+
+    def test_extra_columns_are_preserved(self):
+        """Columns beyond E-value and nt_qlen must survive the filter unchanged."""
+        nt_qlen = 100
+        evalue = _short_cutoff(nt_qlen) * 0.5
+        df = pd.DataFrame({
+            "E-value": [evalue],
+            "nt_qlen": [nt_qlen],
+            "target name": ["some_target"],
+            "query name": ["some_query"],
+        })
+        result = biorisk_evalue_filter(df)
+        assert "target name" in result.columns
+        assert result["target name"].iloc[0] == "some_target"

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -586,7 +586,7 @@
         "BENIGNPROT": {
           "recommendation": {
             "status": "Flag (Cleared)",
-            "from_step": "Benign Protein Search"
+            "from_step": "Low Concern Protein Search"
           },
           "name": "BENIGNPROT",
           "description": "",
@@ -606,7 +606,7 @@
         "BENIGNRNA": {
           "recommendation": {
             "status": "Flag (Cleared)",
-            "from_step": "Benign RNA Search"
+            "from_step": "Low Concern RNA Search"
           },
           "name": "BENIGNRNA",
           "description": "BenignCMTestOutput",
@@ -624,7 +624,7 @@
         "BENIGNSYNBIO": {
           "recommendation": {
             "status": "Flag (Cleared)",
-            "from_step": "Benign DNA Search"
+            "from_step": "Low Concern DNA Search"
           },
           "name": "BENIGNSYNBIO",
           "description": "BENIGNSYNBIO",

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -1,6 +1,6 @@
 {
   "commec_info": {
-    "commec_version": "1.0.3",
+    "commec_version": "1.0.4",
     "json_output_version": "0.3",
     "time_taken": "00:00:02",
     "date_run": "2025-12-03 16:57:20",

--- a/commec/tests/test_fetch_nc_bits.py
+++ b/commec/tests/test_fetch_nc_bits.py
@@ -19,36 +19,53 @@ from commec.tools.blastx import BlastXHandler
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs")
 
 @pytest.mark.parametrize(
-    "hits, nc_ranges",
+    "hits, query_length, nc_ranges",
     [
         # Two protein hits, no noncoding regions > 50bp
-        ([(1, 50), (100, 150), (175, 299)], []),
+        ([(1, 50), (100, 150), (175, 299)], 300, []),
         # One protein hit, < 50bp nocoding regions on the ends
-        ([(50, 251)], []),
+        ([(50, 251)], 300, []),
         # One protein hit, > 50bp nocoding regions on the ends
-        ([(51, 250)], [(1, 50), (251, 300)]),
+        ([(51, 250)], 300, [(1, 50), (251, 300)]),
         # Three protein hits, one noncoding region >50bp
         (
             [(1, 40), (140, 265), (300, 349)],
+            300,
             [(41, 139)],
         ),
+        # Regression: reported by Synplogen. When a lower-identity hit
+        # encompasses a higher-identity one, the coding region is the union of
+        # both hits, so for hits [(400, 600), (200, 800)] on a 1000 bp query the
+        # only non-coding regions are [1, 199] and [801, 1000].
+        # Previously _get_ranges_with_no_hits walked hits pairwise in
+        # sorted-by-start order and used hit_ranges[-1][1] (= 600, the end of
+        # [400, 600]) as the rightmost covered base, incorrectly returning
+        # [(1, 199), (601, 1000)] and re-screening [601, 800] at the nucleotide
+        # level even though it is covered by the [200, 800] protein hit.
+        ([(400, 600), (200, 800)], 1000, [(1, 199), (801, 1000)]),
+        # Fully nested: inner hit is entirely inside the outer one.
+        ([(100, 200), (120, 180)], 300, [(1, 99), (201, 300)]),
+        # Partial overlap on the right.
+        ([(100, 250), (200, 400)], 500, [(1, 99), (401, 500)]),
+        # Adjacent hits (no gap between them) should be treated as one coding block.
+        ([(60, 150), (151, 240)], 300, [(1, 59), (241, 300)]),
     ],
 )
-def test_get_ranges_with_no_hits(hits, nc_ranges):
+def test_get_ranges_with_no_hits(hits, query_length, nc_ranges):
     """
     Test the BLAST hits are successfully converted into noncoding ranges.
     """
 
-    def _create_mock_blast_df_from(hits):
+    def _create_mock_blast_df_from(hits, query_length):
         data = {
             "q. start": [hit[0] for hit in hits],
             "q. end": [hit[1] for hit in hits],
-            "query length": [300] * len(hits),
+            "query length": [query_length] * len(hits),
         }
         df = pd.DataFrame(data)
         return df.reset_index(drop=True)  # This adds a numeric index
 
-    blast_df = _create_mock_blast_df_from(hits)
+    blast_df = _create_mock_blast_df_from(hits, query_length)
     assert _get_ranges_with_no_hits(blast_df) == nc_ranges
 
 

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -19,9 +19,9 @@ def expected_defaults():
         },
         "databases": {
             "low_concern": {
-                "rna": {"path": "commec-dbs/low_concern/rna/benign.cm"},
-                "dna": {"path": "commec-dbs/low_concern/dna/benign.fasta"},
-                "protein": {"path": "commec-dbs/low_concern/protein/benign.hmm"},
+                "rna": {"path": "commec-dbs/low_concern/rna/low_concern.cm"},
+                "dna": {"path": "commec-dbs/low_concern/dna/low_concern.fasta"},
+                "protein": {"path": "commec-dbs/low_concern/protein/low_concern.hmm"},
                 "annotations": 'commec-dbs/low_concern/low_concern_annotations.tsv',
                 "taxids": "commec-dbs/low_concern/vax_taxids.txt"
             },
@@ -73,9 +73,9 @@ def expected_updated_from_custom_yaml():
         },
         "databases": {
             "low_concern": {
-                "rna": {"path": "commec-dbs/low_concern/rna/benign.cm"},
-                "dna": {"path": "commec-dbs/low_concern/dna/benign.fasta"},
-                "protein": {"path": "commec-dbs/low_concern/protein/benign.hmm"},
+                "rna": {"path": "commec-dbs/low_concern/rna/low_concern.cm"},
+                "dna": {"path": "commec-dbs/low_concern/dna/low_concern.fasta"},
+                "protein": {"path": "commec-dbs/low_concern/protein/low_concern.hmm"},
                 "annotations": 'commec-dbs/low_concern/low_concern_annotations.tsv',
                 "taxids": "commec-dbs/low_concern/vax_taxids.txt"
             },

--- a/commec/tests/test_screen.py
+++ b/commec/tests/test_screen.py
@@ -104,6 +104,27 @@ def test_screen_factory(tmp_path):
     assert result.queries["query_01"].status.nucleotide_taxonomy == ScreenStatus.FLAG
     assert result.queries["query_01"].status.low_concern == ScreenStatus.FLAG
 
+def test_low_concern_multiquery(tmp_path):
+    """
+    Checks that the low concern hits are correctly accessed when multiple queries are used, and 
+    the low concern databases have multiple hits across all queries.
+    """
+    screen_test = ScreenTesterFactory("lowconcern_multiquerycheck", tmp_path)
+    screen_test.add_query("query1", 1000)
+    screen_test.add_query("query2", 1000)
+    screen_test.add_query("query3", 1000)
+    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 400, 600, "ClearMe", "RR55", 500, regulated=True)
+    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query2", 400, 600, "ClearMe", "RR55", 500, regulated=True)
+    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query3", 400, 600, "ClearMe", "RR55", 500, regulated=True)
+    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query1", 100, 900, "ClearProtein", "RR55CLEAR", 500)
+    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query2", 100, 900, "ClearProtein", "RR55CLEAR", 500)
+    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query3", 100, 900, "ClearProtein", "RR55CLEAR", 500)
+    result = screen_test.run()
+
+    assert result.queries["query1"].status.screen_status == ScreenStatus.CLEARED_FLAG
+    assert result.queries["query2"].status.screen_status == ScreenStatus.CLEARED_FLAG
+    assert result.queries["query3"].status.screen_status == ScreenStatus.CLEARED_FLAG
+
 def test_different_regions(tmp_path):
     """
     Creates a single hit, with many regions, then a single clear on one of those regions.

--- a/commec/tools/fetch_nc_bits.py
+++ b/commec/tools/fetch_nc_bits.py
@@ -47,24 +47,35 @@ def _get_ranges_with_no_hits(input_df : pd.DataFrame):
     # Sort each pair to ensure that start < end, then sort entire list of ranges
     hit_ranges = sorted([sorted(pair) for pair in hit_ranges])
 
+    # Merge overlapping / adjacent intervals so coverage is computed from the
+    # union of hits, not pairwise. This handles nested and partially-overlapping
+    # hits correctly (e.g. a lower-identity hit that extends beyond a stronger
+    # one on either side).
+    merged : list[list[int]] = []
+    for start, end in hit_ranges:
+        if merged and start <= merged[-1][1] + 1:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+
     nc_ranges : list[tuple[int,int]] = []
+    query_length = int(input_df["query length"].iloc[0])
 
     # Include the start if the first hit begins more than 50 bp after the start
-    if hit_ranges[0][0] > 50:
-        nc_ranges.append((1, hit_ranges[0][0] - 1))
+    if merged[0][0] > 50:
+        nc_ranges.append((1, merged[0][0] - 1))
 
-    # Add ranges if there is a noncoding region of >=50 between hits
-    for i in range(len(hit_ranges) - 1):
-        nc_start = hit_ranges[i][1] + 1  # starts after this hit
-        nc_end = hit_ranges[i + 1][0] - 1 # ends before next hit
+    # Add ranges if there is a noncoding region of >=50 between merged hits
+    for i in range(len(merged) - 1):
+        nc_start = merged[i][1] + 1  # starts after this hit
+        nc_end = merged[i + 1][0] - 1  # ends before next hit
 
         if nc_end - nc_start + 1 >= 50:
             nc_ranges.append((nc_start, nc_end))
 
     # Include the end if the last hit ends more than 50 bp before the end
-    query_length = input_df["query length"].iloc[0]
-    if query_length - hit_ranges[-1][1] >= 50:
-        nc_ranges.append((hit_ranges[-1][1] + 1, int(query_length)))
+    if query_length - merged[-1][1] >= 50:
+        nc_ranges.append((merged[-1][1] + 1, query_length))
 
     return nc_ranges
 

--- a/commec/utils/dict_utils.py
+++ b/commec/utils/dict_utils.py
@@ -6,13 +6,16 @@ Static functions useful for dealing with common dictionary tasks.
 
 @staticmethod
 def deep_update(to_update: dict[str, any], 
-                has_updates: dict[str, any]) -> tuple[
+                has_updates: dict[str, any],
+                accept_new_keys: bool = False) -> tuple[
                     dict[str,any], 
                     list[tuple[str,any]]]:
     """
     Recursively update a nested dictionary without completely overwriting nested dictionaries.
     Only already existing keys are updated. Any keys not existing in the dictionary
     to be updated are returned as a list of rejected key value pairs.
+
+    The highly customizable base_paths dict is checked, and entries preserved.
     -----
     Inputs:
     * to_update : dict[str, any] Dictionary to be updated.
@@ -29,10 +32,11 @@ def deep_update(to_update: dict[str, any],
     for key, value in has_updates.items():
         # If both values are dictionaries, recursively update
         if key in updated and isinstance(updated[key], dict) and isinstance(value, dict):
-            updated[key], additional_rejects = deep_update(updated[key], value)
+            accept_next : bool = (key == "base_paths")
+            updated[key], additional_rejects = deep_update(updated[key], value, accept_next)
             rejected.extend(additional_rejects)
-        # If not a dictionary, just copy the value.
-        elif key in updated:
+        # If not a dictionary, just copy the value, forced if required.
+        elif key in updated or accept_new_keys:
             updated[key] = value
         # If not present, we log an unexpected input one.
         else:

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -102,11 +102,11 @@ def overlay_text_from_hit(hit : HitResult):
         case ScreenStep.TAXONOMY_NT:
             return "Nucl. "+outcome
         case ScreenStep.LOW_CONCERN_PROTEIN:
-            return "Benign Protein"
+            return "Low Concern Protein"
         case ScreenStep.LOW_CONCERN_RNA:
-            return "Benign RNA"
+            return "Low Concern RNA"
         case ScreenStep.LOW_CONCERN_DNA:
-            return "Benign DNA"
+            return "Low Concern DNA"
 
 def generate_html_from_screen_data(input_data : ScreenResult, output_file : str):
     """

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "commec" %}
-{% set version = "1.0.3" %}
+{% set version = "1.0.4" %}
 {% set sha256 = "" %}
 
 package:

--- a/example_data/input_commec-examples/commec-examples_config.yaml
+++ b/example_data/input_commec-examples/commec-examples_config.yaml
@@ -8,11 +8,11 @@ databases:
   low_concern:
     annotations: /mnt/data/home/ec2-user/cm-dbs/low_concern/low_concern_annotations.tsv
     dna:
-      path: /mnt/data/home/ec2-user/cm-dbs/low_concern/dna/benign.fasta
+      path: /mnt/data/home/ec2-user/cm-dbs/low_concern/dna/low_concern.fasta
     protein:
-      path: /mnt/data/home/ec2-user/cm-dbs/low_concern/protein/benign.hmm
+      path: /mnt/data/home/ec2-user/cm-dbs/low_concern/protein/low_concern.hmm
     rna:
-      path: /mnt/data/home/ec2-user/cm-dbs/low_concern/rna/benign.cm
+      path: /mnt/data/home/ec2-user/cm-dbs/low_concern/rna/low_concern.cm
     taxids: /mnt/data/home/ec2-user/cm-dbs/low_concern/vax_taxids.txt
   regulated_nt:
     path: /mnt/data/home/ec2-user/cm-dbs/nt_blast/core_nt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commec"
-version = '1.0.3'
+version = '1.0.4'
 requires-python = ">=3.10"
 # This is not a pure python project; dependencies are managed through environment.yml
 authors = [


### PR DESCRIPTION
## Background
Minor updates for `commec screen`, including bug-fixes, coupled with an updated Biorisk and low-concern databases (databases v.1.0.1).

## Changes
* benign database files are expected to be named low_concern.* by default, as per the v1.0.1 databases release.
* E-Value cut-offs are modified dependent on query sequence length for improved sensitivity.
* Non-coding region calculations no longer truncate when protein hits overlapped under some circumstances.
* Custom base_paths in the configuration yaml that are not the default are correctly propagated throughout the input settings. 

### Breaking changes 
* Default yaml config files will look for low_concern.* instead of benign.* database files within the low_concern directory.