### PR TITLE
Query description handling

### DIFF
--- a/commec/config/query.py
+++ b/commec/config/query.py
@@ -21,6 +21,7 @@ class Query:
         Query.validate_sequence_record(seq_record)
         self._seq_record = seq_record
         self.name = self.create_id(seq_record.id)
+        self.description = seq_record.description[len(seq_record.id):].strip()
         self.non_coding_regions : list[tuple[int, int]] = [] # 1 based coordinates for Non-Coding Regions.
         self.result : QueryResult = None
         self.translations: list[QueryTranslation] = []

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -421,6 +421,7 @@ class QueryResult:
     Container to hold screening result data pertinant to a single Query
     """
     query: str = ""
+    description: str = ""
     length: int = 0
     status: QueryScreenStatus = field(default_factory=QueryScreenStatus)
     hits: dict[str, HitResult] = field(default_factory=dict)

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -128,7 +128,7 @@ class ScreenIO:
                 # Override the original cleaned fasta, with queries above a given length and updated names
                 if len(record.seq) > MINIMUM_QUERY_LENGTH:
                     # Creating new SeqRecord to avoid overwriting the seq_record object inside query and preserve the original seq id
-                    updated_records.append(SeqRecord(record.seq, id=query.name))
+                    updated_records.append(SeqRecord(record.seq, id=query.name, description=""))
             except Exception as e:
                 raise IoValidationError(f"Failed to parse input fasta: {self.nt_path}, {e}") from e
 

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -18,12 +18,14 @@ import yaml
 from yaml.parser import ParserError
 
 from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
 
 from commec.config.query import Query
 from commec.config.constants import (
     DEFAULT_CONFIG_YAML_PATH,
     MINIMUM_QUERY_LENGTH,
     MAXIMUM_FILENAME_SIZE,
+    MAXIMUM_QUERY_NAME_LENGTH,
 )
 from commec.utils.file_utils import expand_and_normalize
 from commec.utils.dict_utils import deep_update
@@ -102,6 +104,7 @@ class ScreenIO:
         Parse queries from FASTA file.
         """
         records = []
+        updated_records = []
         queries = {}
 
         try:
@@ -120,20 +123,17 @@ class ScreenIO:
                 query = Query(record)
                 if query.name in queries:
                     raise ValueError(f"Duplicate sequence identifier generated: \"{query.name}\" from record: {record}\n"
-                                     "Ensure that the first 25 characters for each fasta record are unique.")
+                                     f"Ensure that the first {MAXIMUM_QUERY_NAME_LENGTH} characters for each fasta record are unique.")
                 queries[query.name] = query
-                # Override the original cleaned fasta, with updated names.
-                record.id = query.name
-                record.name = ""
-                record.description = ""
+                # Override the original cleaned fasta, with queries above a given length and updated names
+                if len(record.seq) > MINIMUM_QUERY_LENGTH:
+                    # Creating new SeqRecord to avoid overwriting the seq_record object inside query and preserve the original seq id
+                    updated_records.append(SeqRecord(record.seq, id=query.name))
             except Exception as e:
                 raise IoValidationError(f"Failed to parse input fasta: {self.nt_path}, {e}") from e
-            
-        # Don't write a cleaned fasta for queries below a given length.
-        records = [record for record in records if len(record.seq) > MINIMUM_QUERY_LENGTH]
 
         with open(self.nt_path, "w", encoding = "utf-8") as fasta_file:
-            SeqIO.write(records, fasta_file, "fasta")
+            SeqIO.write(updated_records, fasta_file, "fasta")
 
         return queries
 
@@ -343,7 +343,7 @@ class ScreenIO:
 
     def _write_clean_fasta(self) -> str:
         """
-        Write a FASTA in which whitespace (including non-breaking spaces) and 
+        Write a FASTA in which whitespace (excluding in header), including non-breaking spaces and 
         illegal characters are replaced with underscores.
         """
 
@@ -353,10 +353,15 @@ class ScreenIO:
         ):
             for line in fin:
                 line = line.strip()
-                modified_line = "".join(
-                    "_" if c.isspace() or c == "\xc2\xa0" or c == "#" else c
-                    for c in line
-                )
+                if line.startswith(">"):
+                    modified_line = "".join(
+                        "_" if c == "\xc2\xa0" or c == "#" else c for c in line
+                    )
+                else:
+                    modified_line = "".join(
+                        "_" if c.isspace() or c == "\xc2\xa0" or c == "#" else c
+                        for c in line
+                    )
                 fout.write(f"{modified_line}{os.linesep}")
 
     @property

--- a/commec/flag.py
+++ b/commec/flag.py
@@ -151,7 +151,8 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
             overall_flag = "No Hits (skipped steps)"
 
         results.append({
-        "name": name,
+        "name": query.query,
+        "description": query.description,
         "filepath": file_path,
         "flag": overall_flag,
         "biorisk": query.status.biorisk,

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -328,6 +328,7 @@ class Screen:
 
                 # Link query to the output data.
                 qr = QueryResult(query.original_name,
+                                 query.description,
                                  query.length)
                 self.screen_data.queries[query.name] = qr
                 query.result = qr

--- a/commec/tests/test_data/flag_tests.json
+++ b/commec/tests/test_data/flag_tests.json
@@ -178,7 +178,7 @@
             }
         },
         "FLAG_TEST_04": {
-            "query": "FLAG_TEST_02",
+            "query": "FLAG_TEST_04",
             "length": 1,
             "status": {
                 "screen_status": "Flag",

--- a/commec/tests/test_flag.py
+++ b/commec/tests/test_flag.py
@@ -19,14 +19,14 @@ def test_flag(tmp_path):
 
     expected_status = textwrap.dedent(
         f"""\
-        name,filepath,flag,biorisk,protein,nucleotide,low_concern,virus_flag,bacteria_flag,eukaryote_flag,low_concern_protein,low_concern_rna,low_concern_dna,rationale
-        FLAG_TEST_01,{SCREEN_DIR}/flag_tests.json,Flag,Flag,Pass,Pass,Flag,False,False,False,False,False,False,
-        FLAG_TEST_02,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,True,False,False,False,False,False,
-        FLAG_TEST_03,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,False,True,False,False,False,False,
-        FLAG_TEST_04,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
-        FLAG_TEST_05,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
-        FLAG_TEST_06,{SCREEN_DIR}/flag_tests.json,Pass,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
-        FCTEST1,{SCREEN_DIR}/functional.json,Flag,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
+        name,description,filepath,flag,biorisk,protein,nucleotide,low_concern,virus_flag,bacteria_flag,eukaryote_flag,low_concern_protein,low_concern_rna,low_concern_dna,rationale
+        FLAG_TEST_01,,{SCREEN_DIR}/flag_tests.json,Flag,Flag,Pass,Pass,Flag,False,False,False,False,False,False,
+        FLAG_TEST_02,,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,True,False,False,False,False,False,
+        FLAG_TEST_03,,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,False,True,False,False,False,False,
+        FLAG_TEST_04,,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
+        FLAG_TEST_05,,{SCREEN_DIR}/flag_tests.json,Flag,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
+        FLAG_TEST_06,,{SCREEN_DIR}/flag_tests.json,Pass,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
+        FCTEST1,,{SCREEN_DIR}/functional.json,Flag,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
         """
     )
     actual_status = status_output.read_text()
@@ -46,14 +46,14 @@ def test_evalportal_format(tmp_path):
 
     expected_status = textwrap.dedent(
         f"""\
-        UUID,filepath,Flag,biorisk,protein,nucleotide,low_concern,virus_flag,bacteria_flag,eukaryote_flag,low_concern_protein,low_concern_rna,low_concern_dna,rationale
-        FLAG_TEST_01,{SCREEN_DIR}/flag_tests.json,1,Flag,Pass,Pass,Flag,False,False,False,False,False,False,
-        FLAG_TEST_02,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,True,False,False,False,False,False,
-        FLAG_TEST_03,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,True,False,False,False,False,
-        FLAG_TEST_04,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
-        FLAG_TEST_05,{SCREEN_DIR}/flag_tests.json,1,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
-        FLAG_TEST_06,{SCREEN_DIR}/flag_tests.json,0,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
-        FCTEST1,{SCREEN_DIR}/functional.json,1,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
+        UUID,description,filepath,Flag,biorisk,protein,nucleotide,low_concern,virus_flag,bacteria_flag,eukaryote_flag,low_concern_protein,low_concern_rna,low_concern_dna,rationale
+        FLAG_TEST_01,,{SCREEN_DIR}/flag_tests.json,1,Flag,Pass,Pass,Flag,False,False,False,False,False,False,
+        FLAG_TEST_02,,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,True,False,False,False,False,False,
+        FLAG_TEST_03,,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,True,False,False,False,False,
+        FLAG_TEST_04,,{SCREEN_DIR}/flag_tests.json,1,Pass,Flag,Pass,Flag,False,False,True,False,False,False,
+        FLAG_TEST_05,,{SCREEN_DIR}/flag_tests.json,1,Pass,Pass,Flag,Flag,True,True,True,False,False,False,
+        FLAG_TEST_06,,{SCREEN_DIR}/flag_tests.json,0,Pass,Mixed,Pass,Pass,True,False,False,False,False,False,
+        FCTEST1,,{SCREEN_DIR}/functional.json,1,Flag,Flag,Flag,Flag,True,False,False,True,True,True,"Matches sequence with pathogenic or toxin function, and protein and nucleotide sequence with regulated organisms; as well as virulence factor; as well as flags cleared as common or non-hazardous."
         """
     )
     actual_status = status_output.read_text()

--- a/commec/tests/test_json.py
+++ b/commec/tests/test_json.py
@@ -123,7 +123,7 @@ def test_adding_data_to_existing():
         input_query.status.biorisk = ScreenStatus.PASS
     
     new_screen_data = ScreenResult()
-    new_screen_data.queries["test01"] = QueryResult("test01", 10, ScreenStatus.FLAG)
+    new_screen_data.queries["test01"] = QueryResult("test01", "description01", 10, ScreenStatus.FLAG)
     write_query = new_screen_data.get_query("test01")
     write_info(write_query)
     assert new_screen_data.queries["test01"].status.biorisk == ScreenStatus.PASS

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -145,6 +145,7 @@ def generate_html_from_screen_data(input_data : ScreenResult, output_file : str)
         # Collect full query data for template
         query_toc.append({
             'name': query.query,
+            'description': query.description,
             'status': query.status.screen_status,
             'length': query.length,
             'rationale': query.status.rationale

--- a/commec/utils/template.html
+++ b/commec/utils/template.html
@@ -292,7 +292,7 @@
                         %>
                         <tr>
                             <td><span class="status-badge ${status_class}">${query['status']}</span></td>
-                            <td><a href="#${query['name']}">${query['name']} (${query['length']} b.p.)</a></td>
+                            <td><a href="#${query['name']}">${query['name']} ${query['description']} (${query['length']} b.p.)</a></td>
                             <td>${query['rationale']}</td>
                         </tr>
                     % endfor
@@ -321,7 +321,7 @@
                     <div class="figure-title">
                         <div>
                             <span class="figure-title-status ${status_class}">${query['status']}</span>
-                            <span class="figure-title-query">${query['name']} (${query['length']} b.p.)</span>
+                            <span class="figure-title-query">${query['name']} ${query['description']} (${query['length']} b.p.)</span>
                         </div>
                         <div class="figure-title-rationale">${query['rationale']}</div>
                     </div>


### PR DESCRIPTION
## Background
The sequence descriptions in the FASTA header are currently being concatenated with the seq ID while replacing all whitespaces and illegal characters with underscores. The query name is then constructed from the first 64 characters and propagated to the HTML, JSON, and CSV outputs. Conventionally, the query ID (up to the first space in the header) and the description following the ID should be reported to allow matching of original seq IDs for downstream analysis (e.g., benchmarking). This PR modifies the query name and description handling to support this. 

## Changes
* The FASTA header lines are now exempt from replacing whitespaces in the FASTA cleaning step, which allows correct parsing of the header. Added description attributes to Query and QueryResult classes. The original seq IDs and descriptions are now reported in the JSON, HTML report, and CSV output. 
### Bug fixes
* Fixed a likely bug that was overwriting original Query seq_record.id by modifying the same SeqIO object after query construction.

## Example
```
>sequence_ID this is the description
ATCGTACATCGTAGCATGCTAGCTAGCTAGCTAGCTAGATCGATCGATGCATGCATGCTAGCTAGCTAGCTAGCTAGCTAGCTACGATGC
```
Before:
<img width="500" height="100" alt="image" src="https://github.com/user-attachments/assets/614f41de-9591-4067-8159-f4de218422d6" />
After:
<img width="400" height="100" alt="image" src="https://github.com/user-attachments/assets/b96b463a-4d7c-4d8c-8c05-e1bf2f208c78" />

