### PR TITLE
Dynamically update stale regulated taxids

### DIFF
--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -13,7 +13,7 @@ import os
 from dataclasses import asdict
 
 import pandas as pd
-
+import pytaxonkit
 from commec.tools.search_handler import SearchHandler
 from commec.config.query import Query
 from commec.tools.blast_tools import (
@@ -121,9 +121,27 @@ def parse_taxonomy_hits(
     # We delay non-debug logging to sort messages via query.
     log_container = {key : [] for key in data.queries.keys()}
 
+    def _get_canonical_taxids(taxids: list[str], db_path: str | os.PathLike, threads: int) -> list[str]:
+        """
+        Retrieve the current canonical taxids to handle NCBI taxonomy updates.
+        """
+        lin = pytaxonkit.lineage(taxids, data_dir=db_path, threads=threads)
+        canonical_taxids = (
+            lin["FullLineageTaxIDs"].map(lambda x: x.split(";")[-1]).tolist()
+        )
+        return canonical_taxids
+    
     # Read in lists of regulated and low_concern tax ids
-    vax_taxids = pd.read_csv(low_concern_taxid_path, header=None).squeeze().astype(str).tolist()
-    reg_taxids = pd.read_csv(biorisk_taxid_path, header=None).squeeze().astype(str).tolist()
+    vax_taxids = _get_canonical_taxids(
+        pd.read_csv(low_concern_taxid_path, header=None).squeeze("columns").astype(str).tolist(),
+        taxonomy_directory,
+        n_threads,
+    )
+    reg_taxids = _get_canonical_taxids(
+        pd.read_csv(biorisk_taxid_path, header=None).squeeze("columns").astype(str).tolist(),
+        taxonomy_directory,
+        n_threads,
+    )
 
     blast = read_blast(search_handler.out_file)
     logger.debug("%s Blast Import: shape: %s preview:\n%s", step, blast.shape, blast.head())

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -13,11 +13,11 @@ import os
 from dataclasses import asdict
 
 import pandas as pd
-import pytaxonkit
 from commec.tools.search_handler import SearchHandler
 from commec.config.query import Query
 from commec.tools.blast_tools import (
     read_blast,
+    get_lineages,
     get_taxonomic_labels,
     get_top_hits
 )
@@ -64,6 +64,15 @@ def _check_inputs(
         return False
 
     return True
+
+def get_canonical_taxids(taxids: pd.Series, db_path: str | os.PathLike, threads: int) -> list[str]:
+    """
+    Retrieve the current canonical taxids to handle NCBI taxonomy updates.
+    """
+    lin = get_lineages(taxids, db_path, threads)
+    canonical_taxids = lin["FullLineageTaxIDs"].map(lambda x: x.split(";")[-1]).tolist()
+    return canonical_taxids
+
 
 def parse_taxonomy_hits(
         search_handler : SearchHandler,
@@ -121,24 +130,14 @@ def parse_taxonomy_hits(
     # We delay non-debug logging to sort messages via query.
     log_container = {key : [] for key in data.queries.keys()}
 
-    def _get_canonical_taxids(taxids: list[str], db_path: str | os.PathLike, threads: int) -> list[str]:
-        """
-        Retrieve the current canonical taxids to handle NCBI taxonomy updates.
-        """
-        lin = pytaxonkit.lineage(taxids, data_dir=db_path, threads=threads)
-        canonical_taxids = (
-            lin["FullLineageTaxIDs"].map(lambda x: x.split(";")[-1]).tolist()
-        )
-        return canonical_taxids
-    
     # Read in lists of regulated and low_concern tax ids
-    vax_taxids = _get_canonical_taxids(
-        pd.read_csv(low_concern_taxid_path, header=None).squeeze("columns").astype(str).tolist(),
+    vax_taxids = get_canonical_taxids(
+        pd.read_csv(low_concern_taxid_path, header=None).squeeze("columns").astype(str),
         taxonomy_directory,
         n_threads,
     )
-    reg_taxids = _get_canonical_taxids(
-        pd.read_csv(biorisk_taxid_path, header=None).squeeze("columns").astype(str).tolist(),
+    reg_taxids = get_canonical_taxids(
+        pd.read_csv(biorisk_taxid_path, header=None).squeeze("columns").astype(str),
         taxonomy_directory,
         n_threads,
     )

--- a/commec/tests/screen_factory.py
+++ b/commec/tests/screen_factory.py
@@ -42,6 +42,13 @@ def skip_biorisk_annotations(_input_file):
     """
     return BIORISK_ANNOTATIONS_DATA
 
+def skip_canonical_taxids(taxids, _db_path, _threads):
+    """
+    Override canonical taxid retrieval, so tests
+    don't require a real taxonomy database.
+    """
+    return taxids.astype(str).tolist()
+
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
 TAXONOMY = pd.DataFrame(columns=["subject acc.","regulated", "superkingdom", "phylum", "genus", "species"])
 BIORISK_ANNOTATIONS_DATA = pd.DataFrame(columns=["ID", "Description", "Must flag"])
@@ -99,6 +106,7 @@ class ScreenTesterFactory:
         # We also patch in the desired CLI arguments to avoid an input yaml, and control output.
         with (patch("commec.screeners.check_reg_path.get_taxonomic_labels", new=skip_taxonomy_info), patch(
                 "commec.screeners.check_biorisk.read_biorisk_annotations", new=skip_biorisk_annotations), patch(
+                "commec.screeners.check_reg_path.get_canonical_taxids", new=skip_canonical_taxids), patch(
             "sys.argv",
             arguments,
         )):

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -4,7 +4,7 @@ import textwrap
 from unittest.mock import patch
 import numpy as np
 import pandas as pd
-from commec.tools.blast_tools import _split_by_tax_id, read_blast, _get_lineages, get_taxonomic_labels
+from commec.tools.blast_tools import _split_by_tax_id, read_blast, get_lineages, get_taxonomic_labels
 
 
 @pytest.fixture
@@ -74,7 +74,7 @@ def test_split_by_tax_id(blast_df: pd.DataFrame):
 def test_get_lineages(mock_lineage, blast_df, lineage_df):
     mock_lineage.return_value = lineage_df
     blast_df = _split_by_tax_id(blast_df)
-    lin = _get_lineages(
+    lin = get_lineages(
         blast_df["subject tax ids"], "commec-dbs/taxonomy/", 8
     )
     # Expect the invalid taxid to be filtered out

--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -88,7 +88,7 @@ def _split_by_tax_id(blast: pd.DataFrame, taxids_col_name="subject tax ids"):
     return split
 
 
-def _get_lineages(taxids, db_path: str | os.PathLike, threads: int):
+def get_lineages(taxids: pd.Series, db_path: str | os.PathLike, threads: int):
     """
     Get the full lineage for each unique taxid. This is needed to determine whether it belongs to
     any regulated pathogen, since pathogens might be regulated at various points in the lineage
@@ -141,7 +141,7 @@ def get_taxonomic_labels(
     blast["genus"] = ""
     blast["species"] = ""
 
-    lin = _get_lineages(blast[TAXIDS_COL], db_path, threads)
+    lin = get_lineages(blast[TAXIDS_COL], db_path, threads)
 
     blast = blast[blast[TAXIDS_COL] != TAXID_SYNTHETIC_CONSTRUCTS]
     blast = blast[blast[TAXIDS_COL] != TAXID_VECTORS]


### PR DESCRIPTION
## Background
We currently compare the taxids of BLAST hits against a static list of regulated taxids. NCBI taxonomy updates to taxids can break this logic. For instance, the taxid for Orthoebolavirus genus has been recently updated to 3044781, but we use 186536 in our reg_taxids list. We also have 186538 for the Zaire ebolavirus strain in our list, which is still valid. Due to this, we flag any hits to ZEBOV, but pass hits to any other strain within the genus as non-regulated taxa, while using the latest NCBI taxonomy database. 

<img width="594" height="937" alt="image" src="https://github.com/user-attachments/assets/bea24e33-6e3d-4c02-a7bc-c7c33c37e8b4" />

As different versions of the NCBI taxonomy database may use different taxids for some regulated taxa, we should dynamically update the reg_taxids from the version that was used for screening.

## Changes

- Added a function to retrieve the current canonical taxids from the taxonomy database used for screening and update the reg_taxids and vax_taxids.

### Bug fixes
- Fixed an issue where SoCs were not being flagged due to updated taxids

Before:
<img width="1176" height="274" alt="image" src="https://github.com/user-attachments/assets/e75e6005-cff6-4f06-9f07-6b3b41cf1fd7" />

After:
<img width="1180" height="273" alt="image" src="https://github.com/user-attachments/assets/a4138edc-9917-475f-8589-31b30bd52996" />

