### PR TITLE
docs: fix initial development command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `commec` package is being actively developed by IBBIS staff. We welcome cont
 that [your channels are configured correctly](http://bioconda.github.io/). Then create the dev environment with:
 
 ```
-conda env create -f environment.yml
+conda env create -f environment.yaml
 conda activate commec-dev
 ```
 


### PR DESCRIPTION
This is literally one character in the README.

Making it so it's easier to copy/paste commands to get set up for development.