### PR TITLE
Overwrite faa fasta each run

### DIFF
--- a/commec/screen.py
+++ b/commec/screen.py
@@ -322,6 +322,9 @@ class Screen:
 
         total_query_length = 0
 
+        # Ensure that the translation aa is cleared.
+        with open(self.params.aa_path, 'w', encoding = "utf-8"): ...
+
         try:
             for query in self.queries.values():
                 logger.debug("Processing query: %s, (%s)", query.name, query.original_name)


### PR DESCRIPTION
Ensures that with each commec screen run, the .faa fasta is created from scratch, rather than appended to with each query. This stops the duplication of queries over many --resume or --force reruns, which caused duplication issue in the biorisk hmmscan outputs.