### PR TITLE
SAST Findings

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/miniconda
+USER root
+
+COPY environment.yaml /requirements/
+
+# Drop the editable install of this project (the source isn't in the build
+# context); it's installed post-create once the workspace is mounted.
+RUN grep -v -- '-e \.' /requirements/environment.yaml \
+    | grep -v -- '- pip:' > /requirements/environment.build.yaml \
+    && conda env create -f /requirements/environment.build.yaml
+
+# Activate the commec-dev env in interactive shells
+RUN conda init bash \
+    && echo "conda activate commec-dev" >> /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "common-mechanism",
+  "remoteUser": "root",
+  "build": {
+    "dockerfile": "Containerfile",
+    "context": "..",
+    "args": {
+      "platform": "amd64"
+    }
+  },
+  "postCreateCommand": "conda run -n commec-dev pip install -e ."
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,127 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and new human contributors) working in this repository.
+
+## What this project is
+
+`commec` is the command-line tool behind the [Common Mechanism for DNA Synthesis
+screening](https://ibbis.bio/common-mechanism/), maintained by IBBIS. It takes an input
+FASTA and screens each sequence for biosecurity concerns, producing a structured JSON
+result, an HTML summary, and a human-readable `.screen` log.
+
+The package installs a single entrypoint, `commec`, with four sub-commands (see
+`commec/cli.py`):
+
+| Sub-command | Module          | Purpose                                                            |
+|-------------|-----------------|--------------------------------------------------------------------|
+| `screen`    | `commec/screen.py` | Run screening on an input FASTA (the core pipeline).            |
+| `flag`      | `commec/flag.py`   | Parse `.screen.json` files in a directory into a CSV of outcomes.|
+| `setup`     | `commec/setup.py`  | Download the reference databases needed for screening.          |
+| `split`     | `commec/split.py`  | Split a multi-record FASTA into one file per record.            |
+
+## The screening pipeline
+
+`commec screen` (see `Screen.run` in `commec/screen.py`) runs up to four steps, each of
+which annotates a shared `ScreenResult` state object:
+
+1. **Biorisk search** — HMM scan (`hmmscan`) against a curated biorisk profile DB.
+2. **Protein taxonomy search** — BLASTX or DIAMOND against NCBI `nr`, to find best matches
+   to regulated pathogens.
+3. **Nucleotide taxonomy search** — BLASTN against `core_nt`, run only on non-coding
+   regions (regions with no strong protein hit). Skippable with `--skip-nt`.
+4. **Low-concern search** — three scans (conserved proteins via `hmmscan`, housekeeping
+   RNAs via `cmscan`, synbio parts via `blastn`) that can *clear* protein/nucleotide hits
+   (but never biorisk hits).
+
+`--skip-tx` runs only the biorisk step.
+
+## Code map
+
+```
+commec/
+  cli.py               # Entrypoint dispatch for the four sub-commands
+  screen.py            # Screen class: orchestrates the pipeline; argument parser lives here
+  flag.py, split.py, setup.py
+  config/
+    result.py          # Output data model: ScreenResult > QueryResult > HitResult; the
+                       #   ScreenStatus / ScreenStep enums; rationale-text generation
+    json_io.py         # (De)serialize ScreenResult <-> JSON (dataclass <-> dict <-> file)
+    query.py           # Query object: parsed FASTA record, translation, coordinates
+    screen_io.py       # ScreenIO: argument/YAML config resolution, file path layout
+    screen_tools.py    # ScreenTools: wires up + validates the search-tool wrappers
+    constants.py       # MIN/MAX query length, e-value thresholds, thread limits
+  screeners/
+    check_biorisk.py, check_reg_path.py, check_low_concern.py   # Parse tool output -> hits
+  tools/               # Thin wrappers around external binaries (hmmer, blastn, blastx,
+                       #   diamond, cmscan) + search_handler.py base class
+  utils/               # Logging, FASTA/file helpers, coordinate math, HTML rendering
+  tests/               # Pytest suite (see Testing below)
+```
+
+## Key data model (read `commec/config/result.py` before touching outputs)
+
+- `ScreenResult` is the root output object: `commec_info`, `query_info`, and
+  `queries: dict[str, QueryResult]`.
+- `QueryResult` holds a `QueryScreenStatus` (`status`) and `hits: dict[str, HitResult]`.
+- `QueryScreenStatus` carries the overall `screen_status` plus per-step statuses:
+  `biorisk`, `protein_taxonomy`, `nucleotide_taxonomy`, `low_concern`, and a `rationale`
+  string.
+- `ScreenStatus` is a `StrEnum` ordered by severity/importance (`NULL` < `SKIP` < `PASS`
+  < `CLEARED_WARN` < `CLEARED_FLAG` < `WARN` < `FLAG` < `STOP` < `ERROR`). Its string
+  *values* are human-facing (`"Flag"`, `"Flag (Cleared)"`, `"Pass"`, …) — keep this in
+  mind when comparing against serialized JSON.
+- The output JSON has its own format version (`JSON_COMMEC_FORMAT_VERSION` in
+  `result.py`); always round-trip through `json_io` rather than hand-writing JSON.
+
+## Dev environment
+
+Dependencies (including the external bioinformatics binaries) are managed by conda, not
+pip alone:
+
+```bash
+conda env create -f environment.yaml   # creates the `commec-dev` env
+conda activate commec-dev               # installs the package editable via `pip -e .`
+```
+
+The non-Python tools (`blast`, `diamond`, `hmmer`, `infernal`) must be on `PATH` for a
+real screen to run; they come from the conda env.
+
+## Testing
+
+Tests live in `commec/tests/` and run with `pytest` (CI: `.github/workflows/automate_tests.yml`
+runs `pytest -vv`).
+
+There are **two distinct testing styles** — know which one you want:
+
+1. **Mocked logic tests** (the majority, e.g. `test_screen.py`). These use
+   `commec/tests/screen_factory.py::ScreenTesterFactory`, which fabricates the
+   *intermediate* search-tool output files and runs `commec screen --resume` against the
+   tiny placeholder databases in `commec/tests/test_dbs/`. External taxonomy/biorisk
+   lookups are monkeypatched out. This exercises the parsing + decision logic **without
+   needing real databases or binaries**. Use this to test pipeline logic.
+   - Build a scenario with `add_query()` / `add_hit(...)`, then `.run()` returns a
+     `ScreenResult` you can assert on.
+   - Exemplar-comparison tests (e.g. `test_functional_screen`) regenerate their expected
+     JSON with `pytest --gen-examples` (see the `--gen-examples` option in `conftest.py`).
+
+2. **End-to-end detection tests** (`commec/tests/test_evaluation.py`). These run the *real*
+   pipeline on real FASTA inputs against real databases and assert on detection outcomes.
+   Test cases are data-driven from `commec/tests/test_data/eval/` — see
+   `commec/tests/test_data/eval/README.md` for the per-case `metadata.yaml` schema. Because
+   the real databases are large and not in the repo, these tests **skip** unless a database
+   directory is provided via `--commec-db-dir <path>` or the `COMMEC_DB_DIR` env var:
+
+   ```bash
+   pytest commec/tests/test_evaluation.py --commec-db-dir /path/to/commec-dbs
+   ```
+
+Run the fast (mocked) suite with a plain `pytest`; it does not require databases.
+
+## Conventions
+
+- Python ≥ 3.10. Match the existing style: module docstrings, type hints, `dataclass`-based
+  state, `logging` (not `print`) in library code.
+- Prefer interacting with the `ScreenResult` dataclasses and `json_io` helpers over raw
+  dicts/JSON, so the output format version stays consistent.
+- `commec/tests/.pylintrc` configures linting for the test package.
+- Don't commit real reference databases or large FASTA inputs; keep test fixtures small.

--- a/commec/__init__.py
+++ b/commec/__init__.py
@@ -1,4 +1,5 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
+
 try:
     __version__ = version("commec")
 except (ImportError, PackageNotFoundError):

--- a/commec/cli.py
+++ b/commec/cli.py
@@ -10,34 +10,45 @@ The subcommands:
 
 Command-line usage:
     - commec screen -d /path/to/databases input.fasta
-    - commec flag /path/to/directory/with/output.screen 
+    - commec flag /path/to/directory/with/output.screen
     - commec split input.fasta
     - commec -h, --help
     - commec -v, --version
 """
+
+from commec import __version__ as COMMEC_VERSION
 from commec.flag import (
     DESCRIPTION as flag_DESCRIPTION,
+)
+from commec.flag import (
     add_args as flag_add_args,
+)
+from commec.flag import (
     run as flag_run,
 )
-from commec.screen import (
-    DESCRIPTION as screen_DESCRIPTION,
-    add_args as screen_add_args,
-    run as screen_run,
-    ScreenArgumentParser
+from commec.screen import DESCRIPTION as screen_DESCRIPTION
+from commec.screen import ScreenArgumentParser
+from commec.screen import add_args as screen_add_args
+from commec.screen import run as screen_run
+from commec.setup import (
+    DESCRIPTION as setup_DESCRIPTION,
+)
+from commec.setup import (
+    add_args as setup_add_args,
+)
+from commec.setup import (
+    run as setup_run,
 )
 from commec.split import (
     DESCRIPTION as split_DESCRIPTION,
+)
+from commec.split import (
     add_args as split_add_args,
+)
+from commec.split import (
     run as split_run,
 )
-from commec.setup import (
-    DESCRIPTION as setup_DESCRIPTION,
-    add_args as setup_add_args,
-    run as setup_run,
-)
 
-from commec import __version__ as COMMEC_VERSION
 
 def main():
     """
@@ -86,10 +97,12 @@ def main():
     elif args.command == "setup":
         setup_run(args)
     elif args.version:
-        print( "Commec  : The Common Mechanism\n"
-              f"Version : {COMMEC_VERSION}\n"
-              "Copyright IBBIS (c) 2021-2025\n"
-              "International Biosecurity and Biosafety Initiative for Science")
+        print(
+            "Commec  : The Common Mechanism\n"
+            f"Version : {COMMEC_VERSION}\n"
+            "Copyright IBBIS (c) 2021-2025\n"
+            "International Biosecurity and Biosafety Initiative for Science"
+        )
     else:
         parser.print_help()
 

--- a/commec/config/json_io.py
+++ b/commec/config/json_io.py
@@ -1,42 +1,45 @@
 #!/usr/bin/env python3
 # Copyright (c) 2021-2024 International Biosecurity and Biosafety Initiative for Science
-'''
-   Set of tools for retrieving and storing information important to screen
-    outputs. Information is stored as a structure of dataclasses (headed by ScreenResult), 
-    and are converted between the dataclass / dict / json_file as required. The
-    conversions are done dynamically, and it is recommended to only use and
-    interact with the dataclasses only, to maintain version format, and not
-    create erroneous outputs to the JSON which wont be read back in. This
-    ensures an expected i/o behaviour.
+"""
+Set of tools for retrieving and storing information important to screen
+ outputs. Information is stored as a structure of dataclasses (headed by ScreenResult),
+ and are converted between the dataclass / dict / json_file as required. The
+ conversions are done dynamically, and it is recommended to only use and
+ interact with the dataclasses only, to maintain version format, and not
+ create erroneous outputs to the JSON which wont be read back in. This
+ ensures an expected i/o behaviour.
 
-    The single exception to this is the "annotations" dictionary, present
-    in the HitDescription, which contains non-structured information, and is
-    populated with differing information under differing keys depending on
-    which step the information is derived (Biorisk, Taxonomy etc)
+ The single exception to this is the "annotations" dictionary, present
+ in the HitDescription, which contains non-structured information, and is
+ populated with differing information under differing keys depending on
+ which step the information is derived (Biorisk, Taxonomy etc)
 
-    In this way, the JSON object serves as a common state, that can be updated
-    whilst not being temporally appended like a log file i.e. .screen file.
+ In this way, the JSON object serves as a common state, that can be updated
+ whilst not being temporally appended like a log file i.e. .screen file.
 
-    The JSON stores all pertinent information of a run.
-'''
+ The JSON stores all pertinent information of a run.
+"""
 
 # Consider whether this can get away with being part of config. rename to IO config?
 
 import json
-import string
 import os
+import string
 from dataclasses import asdict, fields, is_dataclass
-from typing import Dict, Type, get_origin, Any, get_args
 from enum import StrEnum
-from commec.config.result import ScreenResult, JSON_COMMEC_FORMAT_VERSION
+from typing import Any, Dict, Type, get_args, get_origin
+
+from commec.config.result import JSON_COMMEC_FORMAT_VERSION, ScreenResult
+
 
 class IoVersionError(RuntimeError):
     """Custom exception when handling differing versions with Commec output JSON."""
 
-def encode_screen_data_to_json(input_result: ScreenResult,
 
-                               output_json_filepath: string = "output.json") -> None:
-    ''' Converts a ScreenResult class object into a JSON file at the given filepath.'''
+def encode_screen_data_to_json(
+    input_result: ScreenResult, output_json_filepath: string = "output.json"
+) -> None:
+    """Converts a ScreenResult class object into a JSON file at the given filepath."""
     try:
         with open(output_json_filepath, "w", encoding="utf-8") as json_file:
             json.dump(asdict(input_result), json_file, indent=2)
@@ -44,18 +47,20 @@ def encode_screen_data_to_json(input_result: ScreenResult,
         print("Error outputting JSON:", e)
         print(input_result)
 
-def encode_dict_to_screen_data(input_dict : dict) -> ScreenResult:
-    ''' Converts a dictionary into a ScreenResult object,
+
+def encode_dict_to_screen_data(input_dict: dict) -> ScreenResult:
+    """Converts a dictionary into a ScreenResult object,
     any keys within the dictionary not part of the ScreenResult format are lost.
-    any missing information will be simple set as defaults.'''
+    any missing information will be simple set as defaults."""
     return dict_to_dataclass(ScreenResult, input_dict)
+
 
 # Convert the dictionary back to the dataclass or list of dataclass
 def dict_to_dataclass(cls: Type, data: Dict[str, Any]) -> Any:
-    '''
+    """
     Convert a dict, into appropriate dataclass, or list of dataclass,
     invalid keys to the dataclass structure are ignored.
-    '''
+    """
     # Prepare a dictionary for filtered data
     filtered_data = {}
 
@@ -80,15 +85,22 @@ def dict_to_dataclass(cls: Type, data: Dict[str, Any]) -> Any:
 
                 # Handle lists of StrEnums
                 if issubclass(item_type, StrEnum):
-                    filtered_data[field_name] = [item_type(item) for item in field_value]
+                    filtered_data[field_name] = [
+                        item_type(item) for item in field_value
+                    ]
 
-                #Handles Dataclasses
+                # Handles Dataclasses
                 if is_dataclass(item_type) and isinstance(field_value, list):
                     filtered_data[field_name] = [
-                        dict_to_dataclass(item_type, item) for item in field_value
-                            if isinstance(item, dict)
-                            and any(key in {f.name for f in fields(item_type)}
-                            for key in item.keys()) or isinstance(item, item_type)]
+                        dict_to_dataclass(item_type, item)
+                        for item in field_value
+                        if isinstance(item, dict)
+                        and any(
+                            key in {f.name for f in fields(item_type)}
+                            for key in item.keys()
+                        )
+                        or isinstance(item, item_type)
+                    ]
                     continue
 
                 filtered_data[field_name] = field_value
@@ -101,8 +113,10 @@ def dict_to_dataclass(cls: Type, data: Dict[str, Any]) -> Any:
                 # Handle dicts of dataclasses
                 if is_dataclass(value_type):
                     filtered_data[field_name] = {
-                        key: dict_to_dataclass(value_type, value) if isinstance(value, dict)
-                        else value for key, value in field_value.items()
+                        key: dict_to_dataclass(value_type, value)
+                        if isinstance(value, dict)
+                        else value
+                        for key, value in field_value.items()
                         if isinstance(value, (dict, value_type))
                     }
                     continue
@@ -115,8 +129,10 @@ def dict_to_dataclass(cls: Type, data: Dict[str, Any]) -> Any:
                 try:
                     filtered_data[field_name] = field_type(field_value)
                 except ValueError:
-                    print(f"Invalid value '{field_value}' for "
-                          f"field '{field_name}' of type {field_type}.")
+                    print(
+                        f"Invalid value '{field_value}' for "
+                        f"field '{field_name}' of type {field_type}."
+                    )
                 continue
 
             # Handle other field types
@@ -125,23 +141,26 @@ def dict_to_dataclass(cls: Type, data: Dict[str, Any]) -> Any:
     # Create an instance of the dataclass with the filtered data
     return cls(**filtered_data)
 
+
 def get_screen_data_from_json(input_json_filepath: string) -> ScreenResult:
-    ''' Loads a JSON file from given filepath and returns
+    """Loads a JSON file from given filepath and returns
     a populated ScreenResult object from its contents. If the file does not
-    exist, then returns a new screen data object.'''
+    exist, then returns a new screen data object."""
     if not os.path.exists(input_json_filepath):
         return ScreenResult()
 
-    json_string : str
+    json_string: str
     with open(input_json_filepath, "r", encoding="utf-8") as json_file:
         # Read the file contents as a string
         json_string = json_file.read()
-    my_data : dict = json.loads(json_string)
+    my_data: dict = json.loads(json_string)
 
     # Check version of imported json.
     input_version = my_data["commec_info"]["json_output_version"]
     if not input_version == JSON_COMMEC_FORMAT_VERSION:
-        raise IoVersionError(f"Version difference between input (v.{input_version}) and"
-                            f" expected (v.{JSON_COMMEC_FORMAT_VERSION})"
-                            f": {input_json_filepath}")
+        raise IoVersionError(
+            f"Version difference between input (v.{input_version}) and"
+            f" expected (v.{JSON_COMMEC_FORMAT_VERSION})"
+            f": {input_json_filepath}"
+        )
     return encode_dict_to_screen_data(my_data)

--- a/commec/config/query.py
+++ b/commec/config/query.py
@@ -3,10 +3,13 @@
 
 import os
 from dataclasses import dataclass
+
 from Bio import Seq
 from Bio.SeqRecord import SeqRecord
-from commec.config.result import QueryResult
+
 from commec.config.constants import MAXIMUM_QUERY_NAME_LENGTH
+from commec.config.result import QueryResult
+
 
 class Query:
     """
@@ -21,11 +24,13 @@ class Query:
         Query.validate_sequence_record(seq_record)
         self._seq_record = seq_record
         self.name = self.create_id(seq_record.id)
-        self.description = seq_record.description[len(seq_record.id):].strip()
-        self.non_coding_regions : list[tuple[int, int]] = [] # 1 based coordinates for Non-Coding Regions.
-        self.result : QueryResult = None
+        self.description = seq_record.description[len(seq_record.id) :].strip()
+        self.non_coding_regions: list[
+            tuple[int, int]
+        ] = []  # 1 based coordinates for Non-Coding Regions.
+        self.result: QueryResult = None
         self.translations: list[QueryTranslation] = []
-        self.no_hits_warning : bool = True # Updated to False whenever any hit is found.
+        self.no_hits_warning: bool = True  # Updated to False whenever any hit is found.
 
     @property
     def original_name(self) -> str:
@@ -122,15 +127,15 @@ class Query:
             )
 
     @staticmethod
-    def create_id(input_name : str) -> str:
+    def create_id(input_name: str) -> str:
         """
-        Parse the Fasta SeqRecord string ID into 
+        Parse the Fasta SeqRecord string ID into
         a constant digit maximum Unique Identification.
         For internal Commec Screen Use only.
         Original Fasta name IDs are used during JSON output.
         """
         # Protections on split name conventions for translation output:
-        name = input_name.split('|')[0]
+        name = input_name.split("|")[0]
 
         # Protection on accidentally ending with _
         if name.endswith("_"):
@@ -138,7 +143,7 @@ class Query:
 
         if len(name) <= MAXIMUM_QUERY_NAME_LENGTH:
             return name
-        
+
         tokens = name.split("_")
 
         if len(tokens) == 1:
@@ -152,32 +157,30 @@ class Query:
             output = testname
 
         return output
-    
 
     def get_non_coding_regions_as_fasta(self) -> str:
-        """ 
+        """
         Return the concatenation of all non-coding regions as a string,
         to be appended to a non_coding fasta file.
         """
         if len(self.non_coding_regions) == 0:
             return ""
-        heading : str = f">{self.name}"
-        sequence : str = ""
+        heading: str = f">{self.name}"
+        sequence: str = ""
         for start, stop in self.non_coding_regions:
-            heading+=f" ({start}-{stop})"
-            sequence+=f"{self._seq_record.seq[int(start)-1: int(stop)]}"
+            heading += f" ({start}-{stop})"
+            sequence += f"{self._seq_record.seq[int(start) - 1 : int(stop)]}"
         return f"{heading}\n{sequence}\n"
 
-    def nc_to_nt_query_coords(self, index : int) -> int:
+    def nc_to_nt_query_coords(self, index: int) -> int:
         """
         Given an index in non-coding coordinates,
         calculate the nucleotide index in query coordinates.
         """
-        nc_pos : int = 1
+        nc_pos: int = 1
         for start, end in self.non_coding_regions:
-            region_length : int = end - start
-            if (index <= (nc_pos + region_length) and
-                index >= nc_pos):
+            region_length: int = end - start
+            if index <= (nc_pos + region_length) and index >= nc_pos:
                 return index - nc_pos + start
 
             nc_pos += region_length + 1
@@ -186,18 +189,19 @@ class Query:
         raise QueryValueError(
             f"Non-coding index provided  ({index}) for {self.name}"
             f"which is out-of-bounds for any known NC start-end tuple: {self.non_coding_regions}"
-            )
-    
+        )
+
     def mark_as_hit(self):
         """
         Confirm that this query has had a valid hit, and therefore, has some
-        sort of homology to something. 
-        
+        sort of homology to something.
+
         TODO: In the future, this could also be passed
         coordinate information to mark some areas of the query identified compared
         to other areas.
         """
         self.no_hits_warning = False
+
 
 @dataclass
 class QueryTranslation:
@@ -211,6 +215,7 @@ class QueryTranslation:
 
     sequence: str
     frame: int
+
 
 class QueryValueError(ValueError):
     """Custom exception for errors when validating a `Query`."""

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -31,7 +31,6 @@ import logging
 from dataclasses import dataclass, asdict, field
 from typing import List, Iterator, Tuple
 from enum import StrEnum
-from importlib.metadata import version, PackageNotFoundError
 import pandas as pd
 from commec.tools.search_handler import SearchToolVersion
 from commec.config.constants import MINIMUM_QUERY_LENGTH, MAXIMUM_QUERY_LENGTH

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -26,18 +26,20 @@ Set of containers for storing information important to screen
          [HitResult]:
              recommendation (per hit)
 """
-import re
+
 import logging
-from dataclasses import dataclass, asdict, field
-from typing import List, Iterator, Tuple
+import re
+from dataclasses import asdict, dataclass, field
 from enum import StrEnum
+from typing import Iterator, List, Tuple
+
 import pandas as pd
-from commec.tools.search_handler import SearchToolVersion
-from commec.config.constants import MINIMUM_QUERY_LENGTH, MAXIMUM_QUERY_LENGTH
+
 from commec import __version__ as COMMEC_VERSION
+from commec.config.constants import MAXIMUM_QUERY_LENGTH, MINIMUM_QUERY_LENGTH
+from commec.tools.search_handler import SearchToolVersion
 
 logger = logging.getLogger(__name__)
-
 
 
 # Seperate versioning for the output JSON.
@@ -83,10 +85,12 @@ class ScreenStatus(StrEnum):
             ScreenStatus.PASS: "Query was not flagged in this screening step; biosecurity review may not be needed",
             ScreenStatus.CLEARED_WARN: (
                 "Warning was cleared, since query region was identified as low-concern"
-                " (e.g. housekeeping gene, common synbio part)"),
+                " (e.g. housekeeping gene, common synbio part)"
+            ),
             ScreenStatus.CLEARED_FLAG: (
                 "Flag was cleared, since query region was identified as low-concern"
-                " (e.g. housekeeping gene, common synbio part)"),
+                " (e.g. housekeeping gene, common synbio part)"
+            ),
             ScreenStatus.WARN: (
                 "Possible sequence of concern identified, but with low confidence"
                 "(e.g. virulence factors or proteins shared among regulated and non-regulated organisms)"
@@ -130,7 +134,7 @@ class ScreenStatus(StrEnum):
         if self == ScreenStatus.CLEARED_FLAG:
             return ScreenStatus.FLAG
         return self
-    
+
     def __gt__(self, value):
         return self.importance > value.importance
 
@@ -142,6 +146,7 @@ class ScreenStatus(StrEnum):
 
     def __le__(self, value):
         return self.importance <= value.importance
+
 
 def compare(a: ScreenStatus, b: ScreenStatus):
     """
@@ -181,7 +186,7 @@ class MatchRange:
     Container for coordinate information of where hits match to a query.
     """
 
-    e_value: float = float('nan')
+    e_value: float = float("nan")
     # percent identity?
     match_start: int = 0
     match_end: int = 0
@@ -192,7 +197,7 @@ class MatchRange:
 
     def length(self):
         """
-        Returns the length in Nucleotides of 
+        Returns the length in Nucleotides of
         this range for the query coordinates.
         """
         return abs(self.query_end - self.query_start)
@@ -218,9 +223,10 @@ class MatchRange:
             and self.query_start == other.query_start
             and self.query_end == other.query_end
         )
-    
+
     def __str__(self):
         return f"{self.query_start}-{self.query_end}"
+
 
 @dataclass(frozen=True)
 class TaxonomyAnnotation:
@@ -228,13 +234,15 @@ class TaxonomyAnnotation:
     Contains basic taxonomy information for the annotations
     dict of a HitResult when determined by a taxonomy step.
     """
-    evalue : float = 0.0
-    taxid : str = ""
+
+    evalue: float = 0.0
+    taxid: str = ""
     species: str = ""
-    genus : str = ""
+    genus: str = ""
     superkingdom: str = ""
-    target_hit : str = ""
-    target_description : str = ""
+    target_hit: str = ""
+    target_description: str = ""
+
 
 @dataclass
 class HitResult:
@@ -260,13 +268,14 @@ class HitResult:
         output = (
             f"{self.name}: {self.description}.\n{self.recommendation.from_step}"
             f", {self.recommendation.status}. Ranges (#{len(self.ranges)})\n"
-            )
+        )
         match_string = ""
         for r in self.ranges:
             match_string += f"{r.query_start}-{r.query_end}, "
         match_string = match_string[:-2]
 
         return output + "[" + match_string + "]"
+
 
 class Rationale(StrEnum):
     """
@@ -276,6 +285,7 @@ class Rationale(StrEnum):
     status is always reported first. After this, secondary less important statuses
     (usually warnings) are added to the rationale.
     """
+
     NULL = "-"
     ERROR = "There was an error during "
 
@@ -299,9 +309,13 @@ class Rationale(StrEnum):
     TAX_WARN = " equally-good matches to regulated and non-regulated organisms"
 
     # Outcomes:
-    NO_HITS = ("No matches found during any stage of analysis. "
-                "Sequence risk is unknown, possibly generated in silico. ")
-    NO_HITS_SKIP_NOTE = NO_HITS + "Matches may be found if re-run without skipping steps."
+    NO_HITS = (
+        "No matches found during any stage of analysis. "
+        "Sequence risk is unknown, possibly generated in silico. "
+    )
+    NO_HITS_SKIP_NOTE = (
+        NO_HITS + "Matches may be found if re-run without skipping steps."
+    )
     SKIPPED = "Query was skipped."
     TOO_LONG = f"Sequence is too long (must be at most {MAXIMUM_QUERY_LENGTH} bp)."
     TOO_SHORT = f"Sequence is too short (must be at least {MINIMUM_QUERY_LENGTH} bp)."
@@ -312,6 +326,7 @@ class Rationale(StrEnum):
     CLEARED = " cleared as common or non-hazardous"
 
     INCOMPLETE = "Screening was not run to completion."
+
 
 @dataclass
 class QueryScreenStatus:
@@ -324,19 +339,21 @@ class QueryScreenStatus:
     protein_taxonomy: ScreenStatus = ScreenStatus.NULL
     nucleotide_taxonomy: ScreenStatus = ScreenStatus.NULL
     low_concern: ScreenStatus = ScreenStatus.NULL
-    rationale : str = Rationale.NULL
+    rationale: str = Rationale.NULL
 
     # Mapping between screen steps and the fields above
     STEP_TO_STATUS_FIELD = {
-        ScreenStep.BIORISK: 'biorisk',
-        ScreenStep.TAXONOMY_NT: 'nucleotide_taxonomy', 
-        ScreenStep.TAXONOMY_AA: 'protein_taxonomy',
-        ScreenStep.LOW_CONCERN_PROTEIN: 'low_concern',
-        ScreenStep.LOW_CONCERN_RNA: 'low_concern',
-        ScreenStep.LOW_CONCERN_DNA: 'low_concern',
+        ScreenStep.BIORISK: "biorisk",
+        ScreenStep.TAXONOMY_NT: "nucleotide_taxonomy",
+        ScreenStep.TAXONOMY_AA: "protein_taxonomy",
+        ScreenStep.LOW_CONCERN_PROTEIN: "low_concern",
+        ScreenStep.LOW_CONCERN_RNA: "low_concern",
+        ScreenStep.LOW_CONCERN_DNA: "low_concern",
     }
 
-    def update_step_status(self, step: ScreenStep, status: ScreenStatus, override_skip: bool = False) -> None:
+    def update_step_status(
+        self, step: ScreenStep, status: ScreenStatus, override_skip: bool = False
+    ) -> None:
         """
         Update the query screen status for a particular step if the proposed status is more
         important than the current one.
@@ -345,7 +362,9 @@ class QueryScreenStatus:
         if status.importance > current_status.importance:
             self.set_step_status(step, status, override_skip)
 
-    def set_step_status(self, step: ScreenStep, status: ScreenStatus, override_skip: bool = False) -> None:
+    def set_step_status(
+        self, step: ScreenStep, status: ScreenStatus, override_skip: bool = False
+    ) -> None:
         """
         Set the query screen status for a particular step.
         In most cases, query steps that have already been skipped should not be updated.
@@ -372,10 +391,12 @@ class QueryScreenStatus:
         # Never override an Error.
         if self.screen_status == ScreenStatus.ERROR:
             return
-        
+
         # This is decided early enough to warrant never overriding.
-        if (self.screen_status == ScreenStatus.SKIP_LONG or 
-            self.screen_status == ScreenStatus.SKIP_SHORT):
+        if (
+            self.screen_status == ScreenStatus.SKIP_LONG
+            or self.screen_status == ScreenStatus.SKIP_SHORT
+        ):
             return
 
         # Derive from the most important step statuses.
@@ -383,22 +404,23 @@ class QueryScreenStatus:
             self.biorisk,
             self.protein_taxonomy,
             self.nucleotide_taxonomy,
-            self.low_concern
+            self.low_concern,
         )
 
         # If a step wasn't completed, then mark screen status as Null.
-        if (ScreenStatus.NULL in {self.biorisk,
-                                  self.protein_taxonomy,
-                                  self.nucleotide_taxonomy,
-                                  self.low_concern}):
+        if ScreenStatus.NULL in {
+            self.biorisk,
+            self.protein_taxonomy,
+            self.nucleotide_taxonomy,
+            self.low_concern,
+        }:
             self.screen_status = ScreenStatus.STOP
             return
 
         # If everything is happy, but we haven't hit anything, time to be suspicious...
-        if (self.screen_status == ScreenStatus.PASS and query_data.no_hits_warning):
+        if self.screen_status == ScreenStatus.PASS and query_data.no_hits_warning:
             self.screen_status = ScreenStatus.WARN
             return
-
 
     def __str__(self) -> str:
         output = f"""
@@ -424,7 +446,7 @@ class QueryScreenStatus:
         if self.low_concern == ScreenStatus.ERROR:
             return "Low concern Screening"
 
-        return "Screening" # General Error at some stage.
+        return "Screening"  # General Error at some stage.
 
 
 @dataclass
@@ -432,6 +454,7 @@ class QueryResult:
     """
     Container to hold screening result data pertinant to a single Query
     """
+
     query: str = ""
     description: str = ""
     length: int = 0
@@ -441,8 +464,8 @@ class QueryResult:
     def get_hit(self, match_name: str) -> HitResult:
         """Wrapper for get logic."""
         return self.hits.get(match_name)
-    
-    def check_hit_range(self, input_region : MatchRange):
+
+    def check_hit_range(self, input_region: MatchRange):
         """
         Checks all existing hits for whether there is an similar query coordinate region.
         Returns the relevant hit, or None.
@@ -475,7 +498,9 @@ class QueryResult:
                     new_region.query_start == existing_region.query_start
                     and new_region.query_end == existing_region.query_end
                 ):
-                    logger.debug(f"[{new_region.query_start}-{new_region.query_end}] Region already exists...")
+                    logger.debug(
+                        f"[{new_region.query_start}-{new_region.query_end}] Region already exists..."
+                    )
                     is_unique_region = False
 
             if is_unique_region:
@@ -504,9 +529,9 @@ class QueryResult:
         """
         logger.debug("Updating step status flags for query %s", self.query)
         logger.debug("Current status %s", self.status)
-        
+
         ignored_status = {ScreenStatus.SKIP, ScreenStatus.ERROR, ScreenStatus.PASS}
-        
+
         if self.status.biorisk not in ignored_status:
             self.status.biorisk = ScreenStatus.NULL
         if self.status.protein_taxonomy not in ignored_status:
@@ -527,57 +552,69 @@ class QueryResult:
         for hit in self.hits.values():
             step = hit.recommendation.from_step
             hit_status = hit.recommendation.status
-        
+
             self.status.update_step_status(step, hit_status, override_skip=True)
 
             if step in status_sets:
                 status_sets[step].add(hit_status)
 
         # Update Benign outcome based on the worst step, or NULL if unfinished.
-        if ScreenStatus.NULL in {self.status.biorisk,
-                                self.status.protein_taxonomy,
-                                self.status.nucleotide_taxonomy}:
+        if ScreenStatus.NULL in {
+            self.status.biorisk,
+            self.status.protein_taxonomy,
+            self.status.nucleotide_taxonomy,
+        }:
             self.status.low_concern = ScreenStatus.NULL
         else:
             self.status.low_concern = max(
                 self.status.low_concern,
                 self.status.biorisk,
                 self.status.protein_taxonomy,
-                self.status.nucleotide_taxonomy
+                self.status.nucleotide_taxonomy,
             )
 
         self.status.update(query_data)
-        self._update_rationale(status_sets[ScreenStep.BIORISK],
-                               status_sets[ScreenStep.TAXONOMY_AA],
-                               status_sets[ScreenStep.TAXONOMY_NT])
+        self._update_rationale(
+            status_sets[ScreenStep.BIORISK],
+            status_sets[ScreenStep.TAXONOMY_AA],
+            status_sets[ScreenStep.TAXONOMY_NT],
+        )
 
         logger.debug("Updated status %s", self.status)
 
-    def _update_rationale(self,
-                          biorisks : set[ScreenStatus],
-                          tax_aa : set[ScreenStatus],
-                          tax_nt : set[ScreenStatus]):
-        """ 
+    def _update_rationale(
+        self,
+        biorisks: set[ScreenStatus],
+        tax_aa: set[ScreenStatus],
+        tax_nt: set[ScreenStatus],
+    ):
+        """
         Check existing statuses, and updates rationale accordingly.
         Requires sets containing unique statuses from each step, as
-        each step is the primary status only. Passing all options 
+        each step is the primary status only. Passing all options
         allows for more depth in rationale texts.
         """
 
         logger.debug("Biorisk set (%d items): %s", len(biorisks), biorisks)
         logger.debug("TAX AA set (%d items): %s", len(tax_aa), tax_aa)
-        logger.debug("TAX NT set (%d items): %s",  len(tax_nt), tax_nt)
+        logger.debug("TAX NT set (%d items): %s", len(tax_nt), tax_nt)
 
-        state = self.status # Shorthand, accessor to be updated
-        tax_all = tax_aa | tax_nt # Check both Taxonomy steps at once
+        state = self.status  # Shorthand, accessor to be updated
+        tax_all = tax_aa | tax_nt  # Check both Taxonomy steps at once
 
         has_flags = state.screen_status == ScreenStatus.FLAG
         has_warns = ScreenStatus.WARN in biorisks | tax_aa | tax_nt
-        has_clears = (ScreenStatus.CLEARED_FLAG in tax_all or
-                      ScreenStatus.CLEARED_WARN in tax_all)
+        has_clears = (
+            ScreenStatus.CLEARED_FLAG in tax_all or ScreenStatus.CLEARED_WARN in tax_all
+        )
 
-        logger.debug("%s has flags [%s], and has warnings [%s], and has clears [%s]",
-                     self.query, has_flags, has_warns, has_clears)
+        logger.debug(
+            "%s has flags [%s], and has warnings [%s], and has clears [%s]",
+            self.query,
+            has_flags,
+            has_warns,
+            has_clears,
+        )
 
         if state.screen_status in {ScreenStatus.ERROR, ScreenStatus.NULL}:
             state.rationale = Rationale.ERROR + state.get_error_stepname()
@@ -603,11 +640,13 @@ class QueryResult:
 
         # Handle no hits warnings
         # --------------------------------------------------------------------
-        if (state.screen_status == ScreenStatus.WARN and
-            state.biorisk == ScreenStatus.PASS and
-            state.protein_taxonomy in [ScreenStatus.PASS, ScreenStatus.SKIP]  and
-            state.nucleotide_taxonomy in [ScreenStatus.PASS, ScreenStatus.SKIP] and
-            state.low_concern in [ScreenStatus.PASS, ScreenStatus.SKIP]):
+        if (
+            state.screen_status == ScreenStatus.WARN
+            and state.biorisk == ScreenStatus.PASS
+            and state.protein_taxonomy in [ScreenStatus.PASS, ScreenStatus.SKIP]
+            and state.nucleotide_taxonomy in [ScreenStatus.PASS, ScreenStatus.SKIP]
+            and state.low_concern in [ScreenStatus.PASS, ScreenStatus.SKIP]
+        ):
             # Add an extra caveat if the taxonomy search was skipped
             if ScreenStatus.SKIP in [state.protein_taxonomy, state.nucleotide_taxonomy]:
                 state.rationale = Rationale.NO_HITS_SKIP_NOTE
@@ -625,8 +664,10 @@ class QueryResult:
         # --------------------------------------------------------------------
         # Calculate any cleared outputs:
         rationales_cleared = ""
-        if (ScreenStatus.CLEARED_FLAG in tax_all and
-            ScreenStatus.CLEARED_WARN in tax_all):
+        if (
+            ScreenStatus.CLEARED_FLAG in tax_all
+            and ScreenStatus.CLEARED_WARN in tax_all
+        ):
             rationales_cleared = Rationale.FLAGWARN
         elif ScreenStatus.CLEARED_FLAG in tax_all:
             rationales_cleared = Rationale.FLAG
@@ -634,16 +675,18 @@ class QueryResult:
             rationales_cleared = Rationale.WARN
         cleared_sentence = rationales_cleared + Rationale.CLEARED
 
-        if state.screen_status in [ScreenStatus.CLEARED_FLAG,
-                                   ScreenStatus.CLEARED_WARN]:
+        if state.screen_status in [
+            ScreenStatus.CLEARED_FLAG,
+            ScreenStatus.CLEARED_WARN,
+        ]:
             state.rationale = Rationale.START_PASS + cleared_sentence
             return
-        
+
         # Handle complex outputs:
         # --------------------------------------------------------------------
         # Start creating rationale message:
         output = Rationale.START_PRIMARY
-    
+
         types = []
         tax_types = []
 
@@ -664,7 +707,7 @@ class QueryResult:
 
             if ScreenStatus.FLAG in tax_all:
                 types.append(tax_types + " " + Rationale.BODY + Rationale.TAX_FLAG)
-            
+
             output += prebody + oxford_comma(types)
 
             if has_warns:
@@ -680,7 +723,6 @@ class QueryResult:
                 types.append(Rationale.BIORISK_WARN)
                 prebody = Rationale.BODY + " "
 
-
             if ScreenStatus.WARN in tax_aa:
                 tax_types.append(Rationale.PR)
             if ScreenStatus.WARN in tax_nt:
@@ -694,22 +736,21 @@ class QueryResult:
                 prebody = ""
 
             output += prebody + oxford_comma(types)
-        
+
         if has_clears:
             output += Rationale.START_SECONDARY[:-1] + cleared_sentence
 
         state.rationale = output + "."
         return
 
-    
     def update(self, query_data):
         """
         Call this before exporting to file.
-        Ensures 
+        Ensures
         Sorts the hits based on E-values,
         Updates the commec recommendation based on all hits recommendations.
         """
-        
+
         assert hasattr(query_data, "no_hits_warning")
 
         # A rare instance where we want our dictionary to be sorted
@@ -751,38 +792,51 @@ class QueryResult:
         self.status.low_concern = ScreenStatus.NULL
         logger.debug("Query %s has screen status assigned to ERROR.", self.query)
 
+
 @dataclass
 class SearchToolInfo:
-    """ Container to hold version info for search tools and databases used. """
-    biorisk_search_info:        SearchToolVersion = field(default_factory=SearchToolVersion)
-    protein_search_info:        SearchToolVersion = field(default_factory=SearchToolVersion)
-    nucleotide_search_info:     SearchToolVersion = field(default_factory=SearchToolVersion)
-    low_concern_protein_search_info: SearchToolVersion = field(default_factory=SearchToolVersion)
-    low_concern_rna_search_info:     SearchToolVersion = field(default_factory=SearchToolVersion)
-    low_concern_dna_search_info:     SearchToolVersion = field(default_factory=SearchToolVersion)
+    """Container to hold version info for search tools and databases used."""
+
+    biorisk_search_info: SearchToolVersion = field(default_factory=SearchToolVersion)
+    protein_search_info: SearchToolVersion = field(default_factory=SearchToolVersion)
+    nucleotide_search_info: SearchToolVersion = field(default_factory=SearchToolVersion)
+    low_concern_protein_search_info: SearchToolVersion = field(
+        default_factory=SearchToolVersion
+    )
+    low_concern_rna_search_info: SearchToolVersion = field(
+        default_factory=SearchToolVersion
+    )
+    low_concern_dna_search_info: SearchToolVersion = field(
+        default_factory=SearchToolVersion
+    )
 
 
 @dataclass
 class ScreenRunInfo:
     """Container dataclass to hold general run information for a commec screen"""
+
     commec_version: str = str(COMMEC_VERSION)
     json_output_version: str = JSON_COMMEC_FORMAT_VERSION
     time_taken: str = ""
     date_run: str = ""
     search_tool_info: SearchToolInfo = field(default_factory=SearchToolInfo)
 
+
 @dataclass
 class ScreenQueryInfo:
-    """ Container for summarising the query input data """
+    """Container for summarising the query input data"""
+
     file: str = ""
     number_of_queries: int = 0
     total_query_length: int = 0
+
 
 @dataclass
 class ScreenResult:
     """
     Root dataclass to hold all data related to the screening of an individual query by commec.
     """
+
     commec_info: ScreenRunInfo = field(default_factory=ScreenRunInfo)
     query_info: ScreenQueryInfo = field(default_factory=ScreenQueryInfo)
     queries: dict[str, QueryResult] = field(default_factory=dict)
@@ -792,7 +846,7 @@ class ScreenResult:
         Wrapper for Query get logic.
         """
         search_term = query_name
-        if re.search(r'_[1-6]$', query_name):  # Check if string ends with _1 to _6
+        if re.search(r"_[1-6]$", query_name):  # Check if string ends with _1 to _6
             search_term = query_name[:-2]  # Remove last two characters
 
         return self.queries.get(search_term)
@@ -830,16 +884,18 @@ class ScreenResult:
         """
         data = []
         for query in self.queries.values():
-            data.append({
-                "query": query.query[:25],
-                "overall": query.status.screen_status,
-                "biorisk": query.status.biorisk,
-                "taxonomy_aa": query.status.protein_taxonomy,
-                "taxonomy_nt": query.status.nucleotide_taxonomy,
-                "cleared": query.status.low_concern
-            })
+            data.append(
+                {
+                    "query": query.query[:25],
+                    "overall": query.status.screen_status,
+                    "biorisk": query.status.biorisk,
+                    "taxonomy_aa": query.status.protein_taxonomy,
+                    "taxonomy_nt": query.status.nucleotide_taxonomy,
+                    "cleared": query.status.low_concern,
+                }
+            )
 
-        output_data : pd.DataFrame = pd.DataFrame(data)
+        output_data: pd.DataFrame = pd.DataFrame(data)
         return output_data
 
     def get_rationale_data(self) -> pd.DataFrame:
@@ -850,25 +906,29 @@ class ScreenResult:
         """
         data = []
         for query in self.queries.values():
-            data.append({
-                "query": query.query[:25],
-                "overall": query.status.screen_status,
-                "rationale": query.status.rationale,
-            })
+            data.append(
+                {
+                    "query": query.query[:25],
+                    "overall": query.status.screen_status,
+                    "rationale": query.status.rationale,
+                }
+            )
 
-        output_data : pd.DataFrame = pd.DataFrame(data)
+        output_data: pd.DataFrame = pd.DataFrame(data)
         return output_data
-    
+
     def rationale_text(self) -> str:
-        """ Outputs the rationale data as formatted text. """
+        """Outputs the rationale data as formatted text."""
         output = ""
         for row in self.get_rationale_data().itertuples(index=False):
             output += f"{row.query:<26}: {row.overall:<12} --> {row.rationale}\n"
         return output
 
     def flag_text(self) -> str:
-        """ Outputs the flag table data as formatted text."""
-        return self.get_flag_data().to_string(index=False, col_space = 12, line_width=2048)
+        """Outputs the flag table data as formatted text."""
+        return self.get_flag_data().to_string(
+            index=False, col_space=12, line_width=2048
+        )
 
     def __str__(self):
         return self.flag_text()
@@ -876,10 +936,11 @@ class ScreenResult:
     def __repr__(self):
         return str(asdict(self))
 
-def oxford_comma(inputs : list[str]) -> str:
+
+def oxford_comma(inputs: list[str]) -> str:
     """
-    Takes a list of strings: 
-        * `[a,b,c]`, 
+    Takes a list of strings:
+        * `[a,b,c]`,
     and outputs a single formatted string:
         * `\"a, b, and c\"`
     """

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -5,38 +5,40 @@ Defines the `ScreenIO` class and associated dataclasses.
 Objects responsible for parsing and interpreting user input for
 the screen workflow of commec.
 """
-import os
-import sys
-import glob
+
 import argparse
+import glob
+import importlib.resources
 import logging
 import multiprocessing
-import importlib.resources
+import os
+import sys
 from pprint import pformat
 
 import yaml
-from yaml.parser import ParserError
-
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
+from yaml.parser import ParserError
 
-from commec.config.query import Query
 from commec.config.constants import (
     DEFAULT_CONFIG_YAML_PATH,
-    MINIMUM_QUERY_LENGTH,
-    MAXIMUM_QUERY_LENGTH,
     MAXIMUM_FILENAME_SIZE,
+    MAXIMUM_QUERY_LENGTH,
     MAXIMUM_QUERY_NAME_LENGTH,
+    MINIMUM_QUERY_LENGTH,
 )
-from commec.utils.file_utils import expand_and_normalize
+from commec.config.query import Query
 from commec.utils.dict_utils import deep_update
+from commec.utils.file_utils import expand_and_normalize
 
 logger = logging.getLogger(__name__)
+
 
 class ScreenIO:
     """
     Container for input settings constructed from arguments to `screen`.
     """
+
     def __init__(self, args: argparse.Namespace):
         # Inputs that do no have a package-level default, since they are specific to each run
         self.db_dir = args.database_dir
@@ -44,7 +46,9 @@ class ScreenIO:
         output_prefix = args.output_prefix
 
         # Output folder hierarchy
-        base, outputs, inputs = self._get_output_prefixes(self.input_fasta_path, output_prefix)
+        base, outputs, inputs = self._get_output_prefixes(
+            self.input_fasta_path, output_prefix
+        )
         self.directory_prefix = base
         self.output_prefix = outputs
         self.input_prefix = inputs
@@ -59,10 +63,11 @@ class ScreenIO:
         # Get configuration based on defaults and CLI args (including YAML config if supplied)
         self.config = {}
         self._read_config(args)
-        
+
         # Check whether a .screen output file already exists.
         if os.path.exists(self.output_screen_file) and not (
-            self.config["force"] or self.config["resume"]):
+            self.config["force"] or self.config["resume"]
+        ):
             logger.error(
                 f"""Screen output {self.output_screen_file} already exists.
                 Either use a different output location, or use --force or --resume to override.
@@ -99,7 +104,6 @@ class ScreenIO:
         self._write_clean_fasta()
         return True
 
-
     def parse_input_fasta(self) -> dict[str, Query]:
         """
         Parse queries from FASTA file.
@@ -109,31 +113,39 @@ class ScreenIO:
         queries = {}
 
         try:
-            with open(self.nt_path, "r", encoding = "utf-8") as fasta_file:
+            with open(self.nt_path, "r", encoding="utf-8") as fasta_file:
                 records = list(SeqIO.parse(fasta_file, "fasta"))
         except ValueError as e:
-            raise IoValidationError(f"Input FASTA file: {self.input_fasta_path} "
-                                    "is not a valid fasta file.") from e
+            raise IoValidationError(
+                f"Input FASTA file: {self.input_fasta_path} is not a valid fasta file."
+            ) from e
 
         if len(records) == 0:
-            raise IoValidationError(f"Input FASTA file: {self.input_fasta_path} "
-                                    " contains no records!")
+            raise IoValidationError(
+                f"Input FASTA file: {self.input_fasta_path}  contains no records!"
+            )
 
         for record in records:
             try:
                 query = Query(record)
                 if query.name in queries:
-                    raise ValueError(f"Duplicate sequence identifier generated: \"{query.name}\" from record: {record}\n"
-                                     f"Ensure that the first {MAXIMUM_QUERY_NAME_LENGTH} characters for each fasta record are unique.")
+                    raise ValueError(
+                        f'Duplicate sequence identifier generated: "{query.name}" from record: {record}\n'
+                        f"Ensure that the first {MAXIMUM_QUERY_NAME_LENGTH} characters for each fasta record are unique."
+                    )
                 queries[query.name] = query
                 # Override the original cleaned fasta, with queries above a given length and updated names
                 if MINIMUM_QUERY_LENGTH < len(record.seq) <= MAXIMUM_QUERY_LENGTH:
                     # Creating new SeqRecord to avoid overwriting the seq_record object inside query and preserve the original seq id
-                    updated_records.append(SeqRecord(record.seq, id=query.name, description=""))
+                    updated_records.append(
+                        SeqRecord(record.seq, id=query.name, description="")
+                    )
             except Exception as e:
-                raise IoValidationError(f"Failed to parse input fasta: {self.nt_path}, {e}") from e
+                raise IoValidationError(
+                    f"Failed to parse input fasta: {self.nt_path}, {e}"
+                ) from e
 
-        with open(self.nt_path, "w", encoding = "utf-8") as fasta_file:
+        with open(self.nt_path, "w", encoding="utf-8") as fasta_file:
             SeqIO.write(updated_records, fasta_file, "fasta")
 
         return queries
@@ -168,18 +180,22 @@ class ScreenIO:
             2. (highest-priority) Configuration provided directly as CLI arguments
         """
         # Read package-level configuration defaults
-        default_yaml = importlib.resources.files("commec").joinpath(DEFAULT_CONFIG_YAML_PATH)
+        default_yaml = importlib.resources.files("commec").joinpath(
+            DEFAULT_CONFIG_YAML_PATH
+        )
         if default_yaml.exists():
             self.config = self._load_config_from_yaml(str(default_yaml))
         else:
             raise FileNotFoundError(
                 f"No default yaml found. Expected at {DEFAULT_CONFIG_YAML_PATH}"
-                )
+            )
 
         # Override configuration with any in user-provided YAML file
-        cli_config_yaml=args.config_yaml.strip()
+        cli_config_yaml = args.config_yaml.strip()
         if os.path.exists(cli_config_yaml):
-            logger.debug(f"Overriding defaults in {default_yaml} with values from {cli_config_yaml}")
+            logger.debug(
+                f"Overriding defaults in {default_yaml} with values from {cli_config_yaml}"
+            )
             self._update_config_from_yaml(cli_config_yaml)
 
         # Override configuration with any user-provided CLI arguments
@@ -196,13 +212,17 @@ class ScreenIO:
         Loads a yaml file, ensuring it's a dictionary.
         """
         try:
-            with open(config_filepath, "r", encoding = "utf-8") as file:
+            with open(config_filepath, "r", encoding="utf-8") as file:
                 config_from_yaml = yaml.safe_load(file)
         except ParserError:
-            raise ValueError(f"Invalid yaml syntax in configuration file: {config_filepath}")
+            raise ValueError(
+                f"Invalid yaml syntax in configuration file: {config_filepath}"
+            )
 
         if not isinstance(config_from_yaml, dict):
-            raise TypeError(f"Loaded configuration file did not result in a dictionary: {file}")
+            raise TypeError(
+                f"Loaded configuration file did not result in a dictionary: {file}"
+            )
         return config_from_yaml
 
     def _update_config_from_yaml(self, config_filepath: str | os.PathLike) -> None:
@@ -213,12 +233,15 @@ class ScreenIO:
         config_from_yaml = self._load_config_from_yaml(config_filepath)
         self.config, rejected = deep_update(self.config, config_from_yaml)
         for rejects in rejected:
-            logger.warning("The follow input from the user provided"
+            logger.warning(
+                "The follow input from the user provided"
                 " configuration was not recognised: %s : %s",
-                rejects[0], rejects[1])
+                rejects[0],
+                rejects[1],
+            )
 
     def _update_config_from_cli(self, args: argparse.Namespace):
-        """ 
+        """
         Override YAML configuration based on arguments given in the command line.
         Need to reference `user_specified_args` because CLI defaults should not override YAML.
         """
@@ -233,12 +256,12 @@ class ScreenIO:
 
         for arg in args.user_specified_args:
             if arg in self.config and hasattr(args, arg):
-                logger.debug(f"Command line arguments updated '{arg}' to: {getattr(args,arg)}")
+                logger.debug(
+                    f"Command line arguments updated '{arg}' to: {getattr(args, arg)}"
+                )
                 self.config[arg] = getattr(args, arg)
 
-    def _format_config_paths(self,
-        db_dir_override: str | os.PathLike = None
-    ):
+    def _format_config_paths(self, db_dir_override: str | os.PathLike = None):
         """
         The YAML file is expected to contain a 'base_paths' key that is referenced in string
         substitutions, so that base paths do not need to be defined more than once. For example:
@@ -252,13 +275,16 @@ class ScreenIO:
         This script will update the dictionary to propagate these substitutions.
         If a database directory is provided, it will override the base_path provided in the yaml.
         """
+
         def recursive_format(nested_yaml, base_paths):
             """
             Recursively apply string formatting to read paths from nested yaml config dicts.
             """
             if isinstance(nested_yaml, dict):
-                return {key : recursive_format(value, base_paths) 
-                        for key, value in nested_yaml.items()}
+                return {
+                    key: recursive_format(value, base_paths)
+                    for key, value in nested_yaml.items()
+                }
             if isinstance(nested_yaml, str):
                 try:
                     return nested_yaml.format(**base_paths)
@@ -267,25 +293,33 @@ class ScreenIO:
                         f"Unknown base path key referenced in path: {nested_yaml}"
                     ) from e
             return nested_yaml
-            
+
         try:
             # Restores legacy behaviour with -d in commec screen CLI, with no yaml.
             if db_dir_override is not None:
-                logger.debug("Command line arguments updated base databases directory: %s", db_dir_override)
+                logger.debug(
+                    "Command line arguments updated base databases directory: %s",
+                    db_dir_override,
+                )
                 self.config["base_paths"]["default"] = db_dir_override
             else:
                 self.db_dir = self.config["base_paths"]["default"]
 
             # Ensure all the base paths end with a separator
             for key, value in self.config["base_paths"].items():
-                self.config["base_paths"][key] = os.path.join(value,'')
-            
+                self.config["base_paths"][key] = os.path.join(value, "")
+
             # Recursively format all paths
-            self.config["base_paths"] = recursive_format(self.config["base_paths"], self.config["base_paths"])
+            self.config["base_paths"] = recursive_format(
+                self.config["base_paths"], self.config["base_paths"]
+            )
             self.config = recursive_format(self.config, self.config["base_paths"])
 
         except TypeError as e:
-            logger.error("Encountered unexpected TypeError during yaml config base path substitution: %s", e)
+            logger.error(
+                "Encountered unexpected TypeError during yaml config base path substitution: %s",
+                e,
+            )
             pass
 
     @staticmethod
@@ -297,7 +331,7 @@ class ScreenIO:
             prefix/input_name/name
 
         - If no prefix was given, use the input filename as name.
-        - If a directory was given, use the input filename 
+        - If a directory was given, use the input filename
             as file prefix within that directory.
         """
         name = os.path.splitext(os.path.basename(input_file))[0]
@@ -324,27 +358,26 @@ class ScreenIO:
         for path in [base, outputs, inputs]:
             os.makedirs(expand_and_normalize(path), exist_ok=True)
 
-        base_prefix = os.path.join(base,name)
-        outputs_prefix =  os.path.join(outputs,name)
-        inputs_prefix =  os.path.join(inputs,name)
+        base_prefix = os.path.join(base, name)
+        outputs_prefix = os.path.join(outputs, name)
+        inputs_prefix = os.path.join(inputs, name)
 
         return base_prefix, outputs_prefix, inputs_prefix
 
-    def output_yaml(self, output_filepath : str | os.PathLike):
+    def output_yaml(self, output_filepath: str | os.PathLike):
         """
-            Takes the current state of the yaml configuration dictionary and 
-            outputs it to a file for posterity, er, reproducibility.
-            
-            Parameters:
-                output_filepath (str | os.PathLike): Path to the output YAML file.
+        Takes the current state of the yaml configuration dictionary and
+        outputs it to a file for posterity, er, reproducibility.
+
+        Parameters:
+            output_filepath (str | os.PathLike): Path to the output YAML file.
         """
         with open(output_filepath, "w", encoding="utf-8") as stream_out:
             yaml.safe_dump(self.config, stream_out, default_flow_style=False)
 
-
     def _write_clean_fasta(self) -> str:
         """
-        Write a FASTA in which whitespace (excluding in header), including non-breaking spaces and 
+        Write a FASTA in which whitespace (excluding in header), including non-breaking spaces and
         illegal characters are replaced with underscores.
         """
 
@@ -371,7 +404,9 @@ class ScreenIO:
 
     @property
     def should_do_nucleotide_screening(self) -> bool:
-        return not (self.config["skip_taxonomy_search"] or self.config["skip_nt_search"])
+        return not (
+            self.config["skip_taxonomy_search"] or self.config["skip_nt_search"]
+        )
 
     @property
     def should_do_low_concern_screening(self) -> bool:

--- a/commec/config/screen_tools.py
+++ b/commec/config/screen_tools.py
@@ -8,14 +8,16 @@ Sets and alters defaults based on input parameters.
 
 import logging
 import os
+
 from commec.config.screen_io import ScreenIO
 from commec.tools.blastn import BlastNHandler
 from commec.tools.blastx import BlastXHandler
-from commec.tools.diamond import DiamondHandler
 from commec.tools.cmscan import CmscanHandler
+from commec.tools.diamond import DiamondHandler
 from commec.tools.hmmer import HmmerHandler
 
 logger = logging.getLogger(__name__)
+
 
 class ScreenTools:
     """
@@ -24,7 +26,7 @@ class ScreenTools:
 
     def __init__(self, params: ScreenIO):
         self.biorisk: HmmerHandler = None
-        self.regulated_protein : BlastXHandler | DiamondHandler = None
+        self.regulated_protein: BlastXHandler | DiamondHandler = None
         self.regulated_nt: BlastNHandler = None
         self.low_concern_hmm: HmmerHandler = None
         self.low_concern_blastn: BlastNHandler = None
@@ -39,9 +41,13 @@ class ScreenTools:
         # (Declared this way for backwards compatibility to old database structure at this stage)
         self.taxonomy_path = params.config["databases"]["taxonomy"]["path"]
         self.biorisk_taxid_path = params.config["databases"]["biorisk"]["taxids"]
-        self.low_concern_taxid_path = params.config["databases"]["low_concern"]["taxids"]
+        self.low_concern_taxid_path = params.config["databases"]["low_concern"][
+            "taxids"
+        ]
         self.biorisk_annotations = params.config["databases"]["biorisk"]["annotations"]
-        self.low_concern_annotations = params.config["databases"]["low_concern"]["annotations"]
+        self.low_concern_annotations = params.config["databases"]["low_concern"][
+            "annotations"
+        ]
 
         # Database tools for Biorisks / Protein and NT screens / Benign screen:
         self.biorisk = HmmerHandler(
@@ -72,8 +78,8 @@ class ScreenTools:
                 self.regulated_protein.jobs = params.config["diamond_jobs"]
                 if params.config["protein_search_tool"] == "nr.dmnd":
                     logger.info(
-                        "Using old \"nr.dmnd\" keyword for search tool will not be supported"
-                        " in future releases,consider using \"diamond\" instead."
+                        'Using old "nr.dmnd" keyword for search tool will not be supported'
+                        ' in future releases,consider using "diamond" instead.'
                     )
             else:
                 raise RuntimeError('Search tool not defined as "blastx" or "diamond"')

--- a/commec/flag.py
+++ b/commec/flag.py
@@ -20,12 +20,17 @@ import argparse
 import glob
 import os
 from json import JSONDecodeError
-import pandas as pd
-from commec.utils.file_utils import directory_arg
-from commec.config.result import ScreenStatus, ScreenResult, ScreenStep, Rationale
-from commec.config.json_io import get_screen_data_from_json, IoVersionError
 
-DESCRIPTION = "Parse all .screen, or .json files in a directory and create CSVs of flags raised"
+import pandas as pd
+
+from commec.config.json_io import IoVersionError, get_screen_data_from_json
+from commec.config.result import Rationale, ScreenResult, ScreenStatus, ScreenStep
+from commec.utils.file_utils import directory_arg
+
+DESCRIPTION = (
+    "Parse all .screen, or .json files in a directory and create CSVs of flags raised"
+)
+
 
 def add_args(parser: argparse.ArgumentParser):
     """
@@ -60,13 +65,14 @@ def add_args(parser: argparse.ArgumentParser):
     )
     return parser
 
+
 def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
     """
     Read JSON screen output and prepare screen_pipline_status CSV.
     """
     results = []
     try:
-        screen_data : ScreenResult = get_screen_data_from_json(file_path)
+        screen_data: ScreenResult = get_screen_data_from_json(file_path)
     except (KeyError, AttributeError, JSONDecodeError):
         return []
     except IoVersionError as e:
@@ -84,18 +90,27 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
 
         qs = query.status
 
-        if (qs.protein_taxonomy
-            not in [ScreenStatus.SKIP, ScreenStatus.ERROR, ScreenStatus.NULL]):
+        if qs.protein_taxonomy not in [
+            ScreenStatus.SKIP,
+            ScreenStatus.ERROR,
+            ScreenStatus.NULL,
+        ]:
             for hit in query.hits.values():
-                if hit.recommendation.from_step in {ScreenStep.TAXONOMY_AA, ScreenStep.TAXONOMY_NT}:
+                if hit.recommendation.from_step in {
+                    ScreenStep.TAXONOMY_AA,
+                    ScreenStep.TAXONOMY_NT,
+                }:
                     for info in hit.annotations["regulated_taxonomy"]:
-                        bacteria_flag  |= (int(info["regulated_bacteria"]) > 0)
-                        virus_flag     |= (int(info["regulated_viruses"]) > 0)
-                        eukaryote_flag |= (int(info["regulated_eukaryotes"]) > 0)
+                        bacteria_flag |= int(info["regulated_bacteria"]) > 0
+                        virus_flag |= int(info["regulated_viruses"]) > 0
+                        eukaryote_flag |= int(info["regulated_eukaryotes"]) > 0
 
         # Which forms of low_concern hits are present?
-        if (qs.low_concern
-            not in [ScreenStatus.SKIP, ScreenStatus.ERROR, ScreenStatus.NULL]):
+        if qs.low_concern not in [
+            ScreenStatus.SKIP,
+            ScreenStatus.ERROR,
+            ScreenStatus.NULL,
+        ]:
             for hit in query.hits.values():
                 match hit.recommendation.from_step:
                     case ScreenStep.LOW_CONCERN_PROTEIN:
@@ -114,14 +129,21 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
         for hit in query.hits.values():
             match hit.recommendation.from_step:
                 case ScreenStep.TAXONOMY_AA:
-                    if hit.recommendation.status in [ScreenStatus.FLAG, ScreenStatus.WARN, ScreenStatus.PASS]:
+                    if hit.recommendation.status in [
+                        ScreenStatus.FLAG,
+                        ScreenStatus.WARN,
+                        ScreenStatus.PASS,
+                    ]:
                         reg_dicts = hit.annotations["regulated_taxonomy"]
                         for r in reg_dicts:
                             if len(r["non_regulated_taxa"]) > 0:
                                 mixed_aa_taxonomy = True
 
                 case ScreenStep.TAXONOMY_NT:
-                    if hit.recommendation.status in [ScreenStatus.FLAG, ScreenStatus.WARN]:
+                    if hit.recommendation.status in [
+                        ScreenStatus.FLAG,
+                        ScreenStatus.WARN,
+                    ]:
                         reg_dicts = hit.annotations["regulated_taxonomy"]
                         for r in reg_dicts:
                             if len(r["non_regulated_taxa"]) > 0:
@@ -140,7 +162,9 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
 
         # We don't like "-" characters (typically representing an error or unset value) being dragged
         # into commec flag outputs when rationale is not present - for backwards tidyness.
-        output_rationale = query.status.rationale if query.status.rationale != Rationale.NULL else ""
+        output_rationale = (
+            query.status.rationale if query.status.rationale != Rationale.NULL else ""
+        )
 
         overall_flag = query.status.screen_status
         if query.status.rationale == Rationale.NO_HITS:
@@ -150,28 +174,32 @@ def read_flags_from_json(file_path) -> list[dict[str, str | set[str] | bool]]:
         if query.status.rationale == Rationale.NO_HITS_SKIP_NOTE:
             overall_flag = "No Hits (skipped steps)"
 
-        results.append({
-        "name": query.query,
-        "description": query.description,
-        "filepath": file_path,
-        "flag": overall_flag,
-        "biorisk": query.status.biorisk,
-        "protein": protein_status,
-        "nucleotide": nucleotide_status,
-        "low_concern": query.status.low_concern,
-        "virus_flag": virus_flag,
-        "bacteria_flag": bacteria_flag,
-        "eukaryote_flag": eukaryote_flag,
-        "low_concern_protein": low_concern_protein,
-        "low_concern_rna": low_concern_rna,
-        "low_concern_dna": low_concern_synbio,
-        "rationale": output_rationale,
-        })
+        results.append(
+            {
+                "name": query.query,
+                "description": query.description,
+                "filepath": file_path,
+                "flag": overall_flag,
+                "biorisk": query.status.biorisk,
+                "protein": protein_status,
+                "nucleotide": nucleotide_status,
+                "low_concern": query.status.low_concern,
+                "virus_flag": virus_flag,
+                "bacteria_flag": bacteria_flag,
+                "eukaryote_flag": eukaryote_flag,
+                "low_concern_protein": low_concern_protein,
+                "low_concern_rna": low_concern_rna,
+                "low_concern_dna": low_concern_synbio,
+                "rationale": output_rationale,
+            }
+        )
 
     return results
 
 
-def write_output_csv(output_dir: str | os.PathLike, status: dict, evalportal_format: bool):
+def write_output_csv(
+    output_dir: str | os.PathLike, status: dict, evalportal_format: bool
+):
     """
     Write flag data results to an output CSV file.
     -----
@@ -181,12 +209,15 @@ def write_output_csv(output_dir: str | os.PathLike, status: dict, evalportal_for
     """
     status_file = os.path.join(output_dir, "screen_pipeline_status.csv")
     status_df = pd.DataFrame(status)
-    status_df = status_df.map(lambda x: ";".join(sorted(x)) if isinstance(x, set) else x)
+    status_df = status_df.map(
+        lambda x: ";".join(sorted(x)) if isinstance(x, set) else x
+    )
 
     if evalportal_format:
         # Using a "strict" mode coverting Flag/Warning to 1, and everything else to 0.
         status_df["flag"] = status_df["flag"].map(
-            lambda x: 1 if x == "Flag" or x == "Warning" else 0)
+            lambda x: 1 if x == "Flag" or x == "Warning" else 0
+        )
         status_df = status_df.rename(columns={"name": "UUID", "flag": "Flag"})
 
     status_df.to_csv(status_file, index=False)
@@ -206,7 +237,9 @@ def run(args: argparse.Namespace):
     evalportal_format = args.evalportal_format
 
     search_pattern = "**/*.json" if search_recursive else "*.json"
-    screen_paths = glob.glob(os.path.join(search_dir, search_pattern), recursive=search_recursive)
+    screen_paths = glob.glob(
+        os.path.join(search_dir, search_pattern), recursive=search_recursive
+    )
 
     if not screen_paths:
         raise FileNotFoundError(f"No .json files were found in directory: {search_dir}")

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -49,61 +49,65 @@ Output file handling:
   -F, --force           Overwrite any pre-existing output for run (cannot be used with --resume)
   -R, --resume          Re-use any pre-existing output run (cannot be used with --force)
 """
+
 import argparse
 import datetime
-import time
 import logging
 import sys
+import time
 import traceback
+
 import pandas as pd
 from Bio.Data.CodonTable import TranslationError
 
-from commec.config.screen_io import ScreenIO, IoValidationError
+from commec.config.constants import MAXIMUM_QUERY_LENGTH, MINIMUM_QUERY_LENGTH
+from commec.config.json_io import encode_screen_data_to_json
 from commec.config.query import Query
-from commec.utils.logger import (
-    setup_console_logging,
-    setup_file_logging,
-    set_log_level,
-)
-from commec.config.screen_tools import ScreenTools
 from commec.config.result import (
-    ScreenResult,
-    ScreenStep,
     QueryResult,
+    ScreenResult,
     ScreenStatus,
+    ScreenStep,
 )
-from commec.utils.file_utils import file_arg, directory_arg
-from commec.utils.json_html_output import generate_html_from_screen_data
+from commec.config.screen_io import IoValidationError, ScreenIO
+from commec.config.screen_tools import ScreenTools
 from commec.screeners.check_biorisk import parse_biorisk_hits
 from commec.screeners.check_low_concern import parse_low_concern_hits
 from commec.screeners.check_reg_path import parse_taxonomy_hits
 from commec.tools.fetch_nc_bits import calculate_noncoding_regions_per_query
 from commec.tools.search_handler import DatabaseValidationError
-from commec.config.json_io import encode_screen_data_to_json
-from commec.config.constants import MINIMUM_QUERY_LENGTH, MAXIMUM_QUERY_LENGTH
+from commec.utils.file_utils import directory_arg, file_arg
+from commec.utils.json_html_output import generate_html_from_screen_data
+from commec.utils.logger import (
+    set_log_level,
+    setup_console_logging,
+    setup_file_logging,
+)
 
 DESCRIPTION = "Run Common Mechanism screening on an input FASTA."
 
 logger = logging.getLogger(__name__)
 
+
 class ScreenArgumentParser(argparse.ArgumentParser):
     """
-    Argument parser that returns a `user_specified_args` namespace item, 
+    Argument parser that returns a `user_specified_args` namespace item,
     which helps selectively override other configuration (e.g. provided via YAML)
     i.e. for only when it has explicitly been used as an argument in CLI.
 
-    Importantly, this iterates over all sub-parsers too, required for the 
-    cli entry point of Commec. However to do this we access various private 
+    Importantly, this iterates over all sub-parsers too, required for the
+    cli entry point of Commec. However to do this we access various private
     parser attributes - which is naughty - but its better than writing our own argsparse.
     """
-    def parse_args(self, args=None, namespace=None):     
+
+    def parse_args(self, args=None, namespace=None):
         # Get argument strings; in most cases, args and sys.argv[1:] will be the same
         cli_strings = args if args is not None else sys.argv[1:]
         user_specified_args = set()
 
-        def collect_user_actions(parser : ScreenArgumentParser):
-            """ 
-            Recursively collect all actions, including subparsers. 
+        def collect_user_actions(parser: ScreenArgumentParser):
+            """
+            Recursively collect all actions, including subparsers.
             _actions has every argument provide to the parser, and
             has every SubParserActions instances.
             """
@@ -114,17 +118,18 @@ class ScreenArgumentParser(argparse.ArgumentParser):
                         collect_user_actions(subparser)
                 else:
                     for arg_string in action.option_strings:
-                        #print("Testing:", arg_string)
+                        # print("Testing:", arg_string)
                         if arg_string in cli_strings:
-                            #print("added!")
+                            # print("added!")
                             user_specified_args.add(action.dest)
 
         # Collect arguments from main parser and all subparsers
         collect_user_actions(self)
-        
+
         ns = super().parse_args(args, namespace)
-        setattr(ns,"user_specified_args", user_specified_args)
+        setattr(ns, "user_specified_args", user_specified_args)
         return ns
+
 
 def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """
@@ -159,15 +164,19 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--skip-tx",
         dest="skip_taxonomy_search",
         action="store_true",
-        help=("Skip taxonomy homology search (only toxins and other proteins"
-              " included in the biorisk database will be flagged)"),
+        help=(
+            "Skip taxonomy homology search (only toxins and other proteins"
+            " included in the biorisk database will be flagged)"
+        ),
     )
     screen_logic_group.add_argument(
         "--skip-nt",
         dest="skip_nt_search",
         action="store_true",
-        help=("Skip nucleotide search (regulated pathogens will only be"
-              " identified based on biorisk database and protein hits)"),
+        help=(
+            "Skip nucleotide search (regulated pathogens will only be"
+            " identified based on biorisk database and protein hits)"
+        ),
     )
 
     screen_logic_group.add_argument(
@@ -178,11 +187,22 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="Tool for protein homology search to identify regulated pathogens",
     )
 
-    screen_logic_group.add_argument('-f', '--fast-mode', action="store_true", deprecated=True,
-                                    help=("(DEPRECATED: legacy commands for --fast-mode, please use"
-                                          " --skip-tx to skip the taxonomy step instead.)"))
-    screen_logic_group.add_argument('-n', action = "store_true", deprecated=True,
-                                    help="(DEPRECATED: shorthand for --skip-nt, use --skip-nt instead.)")
+    screen_logic_group.add_argument(
+        "-f",
+        "--fast-mode",
+        action="store_true",
+        deprecated=True,
+        help=(
+            "(DEPRECATED: legacy commands for --fast-mode, please use"
+            " --skip-tx to skip the taxonomy step instead.)"
+        ),
+    )
+    screen_logic_group.add_argument(
+        "-n",
+        action="store_true",
+        deprecated=True,
+        help="(DEPRECATED: shorthand for --skip-nt, use --skip-nt instead.)",
+    )
 
     parallel_group = parser.add_argument_group("Parallelisation")
     parallel_group.add_argument(
@@ -207,7 +227,7 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         dest="output_prefix",
         help="Prefix for output files. Can be a string (interpreted as output basename) or a"
         + " directory (files will be output there, names will be determined from input FASTA)",
-        default = ""
+        default="",
     )
     output_handling_group.add_argument(
         "-c",
@@ -232,52 +252,64 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     )
     return parser
 
+
 class Screen:
     """
     Handles the parsing of input arguments, the control of databases, and
     the logical flow of the screening process for commec.
     """
+
     def early_exit(self):
         """
         Exit commec screen early, wrapper for sys.ext() for tidy logging.
         """
         logger.info("Commec screen will now exit ... ")
-        logger.info("", extra={"no_prefix" : True, "box_up" : True})
+        logger.info("", extra={"no_prefix": True, "box_up": True})
         sys.exit(1)
 
     def __init__(self):
-        self.params : ScreenIO = None
-        self.queries : dict[str, Query] = None
-        self.database_tools : ScreenTools = None
-        self.screen_data : ScreenResult = ScreenResult()
+        self.params: ScreenIO = None
+        self.queries: dict[str, Query] = None
+        self.database_tools: ScreenTools = None
+        self.screen_data: ScreenResult = ScreenResult()
         self.start_time = time.time()
         self.success = False
 
     def __del__(self):
-        """ 
+        """
         Before we are finished, we attempt to write a JSON and HTML output.
         Doing this in the destructor means that sometimes this will complete
         successfully, despite exceptions, and premature exits.
         """
         if not self.params:
-            #Setup failed, so no need to output anything
+            # Setup failed, so no need to output anything
             return
 
-        time_taken = (time.time() - self.start_time)
+        time_taken = time.time() - self.start_time
         hours, rem = divmod(time_taken, 3600)
         minutes, seconds = divmod(rem, 60)
-        self.screen_data.commec_info.time_taken = f"{int(hours):02}:{int(minutes):02}:{int(seconds):02}"
+        self.screen_data.commec_info.time_taken = (
+            f"{int(hours):02}:{int(minutes):02}:{int(seconds):02}"
+        )
         self.screen_data.update(self.queries)
         encode_screen_data_to_json(self.screen_data, self.params.output_json)
 
-        logger.debug("\n >> EXPORT JSON SUMMARY : \n%s",
-                    self.screen_data.flag_text(), extra={"no_prefix" : True})
-        logger.debug("\n >> RATIONALE : \n%s",
-                    self.screen_data.rationale_text(), extra={"no_prefix" : True})
+        logger.debug(
+            "\n >> EXPORT JSON SUMMARY : \n%s",
+            self.screen_data.flag_text(),
+            extra={"no_prefix": True},
+        )
+        logger.debug(
+            "\n >> RATIONALE : \n%s",
+            self.screen_data.rationale_text(),
+            extra={"no_prefix": True},
+        )
 
         # Only output the HTML, and cleanup if this was a successful run:
         if self.success:
-            generate_html_from_screen_data(self.screen_data, self.params.directory_prefix+"_summary")
+            generate_html_from_screen_data(
+                self.screen_data, self.params.directory_prefix + "_summary"
+            )
             if self.params.config["do_cleanup"]:
                 self.params.clean()
 
@@ -287,7 +319,10 @@ class Screen:
         # Start logging to console
         log_level = logging.INFO if not args.verbose else logging.DEBUG
         setup_console_logging(log_level)
-        logger.info(" The Common Mechanism : Screen", extra={"no_prefix": True, "box_down" : True})
+        logger.info(
+            " The Common Mechanism : Screen",
+            extra={"no_prefix": True, "box_down": True},
+        )
 
         logger.debug("Parsing input parameters...")
         self.params: ScreenIO = ScreenIO(args)
@@ -306,12 +341,14 @@ class Screen:
         logger.info("Validating input parameters, query and databases...")
         try:
             self.database_tools: ScreenTools = ScreenTools(self.params)
-        except(DatabaseValidationError) as e:
+        except DatabaseValidationError as e:
             logger.error(e)
             self.early_exit()
 
         logger.info("Input query file: ")
-        logger.info(self.params.input_fasta_path, extra={"no_prefix":True,"cap":True})
+        logger.info(
+            self.params.input_fasta_path, extra={"no_prefix": True, "cap": True}
+        )
 
         # Initialize the queries
         try:
@@ -323,28 +360,37 @@ class Screen:
         total_query_length = 0
 
         # Ensure that the translation aa is cleared.
-        with open(self.params.aa_path, 'w', encoding = "utf-8"): ...
+        with open(self.params.aa_path, "w", encoding="utf-8"):
+            ...
 
         try:
             for query in self.queries.values():
-                logger.debug("Processing query: %s, (%s)", query.name, query.original_name)
+                logger.debug(
+                    "Processing query: %s, (%s)", query.name, query.original_name
+                )
 
                 # Link query to the output data.
-                qr = QueryResult(query.original_name,
-                                 query.description,
-                                 query.length)
+                qr = QueryResult(query.original_name, query.description, query.length)
                 self.screen_data.queries[query.name] = qr
                 query.result = qr
 
                 # Determine out-of-range queries as skipped:
                 if query.length < MINIMUM_QUERY_LENGTH:
-                    logger.warning("%s length %i is less than %i",
-                                    query.name, query.length, MINIMUM_QUERY_LENGTH)
+                    logger.warning(
+                        "%s length %i is less than %i",
+                        query.name,
+                        query.length,
+                        MINIMUM_QUERY_LENGTH,
+                    )
                     qr.skip(ScreenStatus.SKIP_SHORT)
                     continue
                 elif query.length > MAXIMUM_QUERY_LENGTH:
-                    logger.warning("%s length %i exceeds maximum %i",
-                                    query.name, query.length, MAXIMUM_QUERY_LENGTH)
+                    logger.warning(
+                        "%s length %i exceeds maximum %i",
+                        query.name,
+                        query.length,
+                        MAXIMUM_QUERY_LENGTH,
+                    )
                     qr.skip(ScreenStatus.SKIP_LONG)
                     continue
 
@@ -352,8 +398,11 @@ class Screen:
                 try:
                     query.translate(self.params.aa_path)
                 except TranslationError as e:
-                    logger.error("An error occured when translating %s:\n %s",
-                                 query.original_name, e)
+                    logger.error(
+                        "An error occured when translating %s:\n %s",
+                        query.original_name,
+                        e,
+                    )
                     qr.error()
                     self.early_exit()
                 total_query_length += query.length
@@ -371,25 +420,35 @@ class Screen:
         _info = self.screen_data.commec_info.search_tool_info
         _info.biorisk_search_info = _tools.biorisk.get_version_information()
         if self.params.should_do_protein_screening:
-            _info.protein_search_info = _tools.regulated_protein.get_version_information()
+            _info.protein_search_info = (
+                _tools.regulated_protein.get_version_information()
+            )
         if self.params.should_do_nucleotide_screening:
             _info.nucleotide_search_info = _tools.regulated_nt.get_version_information()
         if self.params.should_do_low_concern_screening:
-            _info.low_concern_protein_search_info = _tools.low_concern_hmm.get_version_information()
-            _info.low_concern_rna_search_info = _tools.low_concern_cmscan.get_version_information()
-            _info.low_concern_dna_search_info = _tools.low_concern_blastn.get_version_information()
+            _info.low_concern_protein_search_info = (
+                _tools.low_concern_hmm.get_version_information()
+            )
+            _info.low_concern_rna_search_info = (
+                _tools.low_concern_cmscan.get_version_information()
+            )
+            _info.low_concern_dna_search_info = (
+                _tools.low_concern_blastn.get_version_information()
+            )
 
         # Store start time.
-        self.screen_data.commec_info.date_run = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.screen_data.commec_info.date_run = datetime.datetime.now().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
 
-    def run(self, args : argparse.Namespace):
+    def run(self, args: argparse.Namespace):
         """
         Wrapper so that args be parsed in main() or commec.py interface.
         """
         # Perform setup steps.
         self.setup(args)
         self.params.output_yaml(self.params.input_prefix + "_config.yaml")
-        
+
         # Biorisk screen
         try:
             logger.info(" >> STEP 1: Checking for biorisk genes...")
@@ -413,7 +472,9 @@ class Screen:
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
-                logger.error("STEP 2: Protein search failed due to an error:\n %s", str(e))
+                logger.error(
+                    "STEP 2: Protein search failed due to an error:\n %s", str(e)
+                )
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_query_statuses(ScreenStep.TAXONOMY_AA, ScreenStatus.ERROR)
         else:
@@ -430,7 +491,10 @@ class Screen:
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
-                logger.error("ERROR STEP 3: Nucleotide search failed due to an error:\n %s", str(e))
+                logger.error(
+                    "ERROR STEP 3: Nucleotide search failed due to an error:\n %s",
+                    str(e),
+                )
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_query_statuses(ScreenStep.TAXONOMY_NT, ScreenStatus.ERROR)
         else:
@@ -449,25 +513,35 @@ class Screen:
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
-                logger.error("STEP 4: Benign search failed due to an error:\n %s", str(e))
+                logger.error(
+                    "STEP 4: Benign search failed due to an error:\n %s", str(e)
+                )
                 logger.info(" Traceback:\n%s", traceback.format_exc())
-                self.reset_query_statuses(ScreenStep.LOW_CONCERN_DNA, ScreenStatus.ERROR)
+                self.reset_query_statuses(
+                    ScreenStep.LOW_CONCERN_DNA, ScreenStatus.ERROR
+                )
         else:
             logger.info(" << SKIPPING STEP 4: Low-concern search")
             self.reset_query_statuses(ScreenStep.LOW_CONCERN_DNA, ScreenStatus.SKIP)
 
         logger.info(
-            " >> Commec Screen completed at %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            " >> Commec Screen completed at %s",
+            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         )
 
         self.screen_data.update(self.queries)
 
-        logger.info("\n >> SUMMARY : \n%s",
-                    self.screen_data.flag_text(), extra={"no_prefix" : True, "box_up":True})
-        logger.info("\n >> RATIONALE : \n%s",
-                    self.screen_data.rationale_text(), extra={"no_prefix" : True})
+        logger.info(
+            "\n >> SUMMARY : \n%s",
+            self.screen_data.flag_text(),
+            extra={"no_prefix": True, "box_up": True},
+        )
+        logger.info(
+            "\n >> RATIONALE : \n%s",
+            self.screen_data.rationale_text(),
+            extra={"no_prefix": True},
+        )
         self.success = True
-
 
     def screen_biorisks(self):
         """
@@ -480,8 +554,9 @@ class Screen:
             self.database_tools.biorisk,
             self.database_tools.biorisk_annotations,
             self.screen_data,
-            self.queries)
-        
+            self.queries,
+        )
+
         if exit_status != 0:
             raise RuntimeError(
                 f"Output of biorisk search could not be processed: {self.database_tools.biorisk.out_file}"
@@ -513,7 +588,7 @@ class Screen:
             self.screen_data,
             self.queries,
             ScreenStep.TAXONOMY_AA,
-            self.params.config["threads"]
+            self.params.config["threads"],
         )
 
         if exit_status != 0:
@@ -534,8 +609,8 @@ class Screen:
 
         # Calculate non-coding information for each Query.
         calculate_noncoding_regions_per_query(
-            self.database_tools.regulated_protein,
-            self.queries)
+            self.database_tools.regulated_protein, self.queries
+        )
 
         # Generate the non-coding fasta.
         nc_fasta_sequences = ""
@@ -576,7 +651,7 @@ class Screen:
             self.screen_data,
             self.queries,
             ScreenStep.TAXONOMY_NT,
-            self.params.config["threads"]
+            self.params.config["threads"],
         )
 
         if exit_status != 0:
@@ -590,7 +665,7 @@ class Screen:
         to `check_low_concern.py` to identify regions that can be cleared.
         """
         # Start by checking if there are any hits that require clearing...
-        hits_to_clear : bool = False
+        hits_to_clear: bool = False
         for _query, hit in self.screen_data.hits():
             if hit.recommendation.status in {ScreenStatus.WARN, ScreenStatus.FLAG}:
                 hits_to_clear = True
@@ -609,7 +684,6 @@ class Screen:
         logger.debug("\t...running low-concern cmscan")
         self.database_tools.low_concern_cmscan.search()
 
-
         # Update Screen Data with low_concern outputs.
         low_concern_desc = pd.read_csv(
             self.params.config["databases"]["low_concern"]["annotations"],
@@ -621,13 +695,14 @@ class Screen:
             self.database_tools.low_concern_cmscan,
             self.database_tools.low_concern_blastn,
             self.queries,
-            low_concern_desc
+            low_concern_desc,
         )
 
-    def reset_query_statuses(self, step: ScreenStep, status : ScreenStatus):
+    def reset_query_statuses(self, step: ScreenStep, status: ScreenStatus):
         """Helper function to apply a single status across a step for every query"""
         for query in self.screen_data.queries.values():
             query.status.set_step_status(step, status)
+
 
 def run(args: argparse.Namespace):
     """
@@ -648,6 +723,7 @@ def main():
     add_args(parser)
     args = parser.parse_args()
     run(args)
+
 
 if __name__ == "__main__":
     try:

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -4,43 +4,48 @@
 Script that checks the output from hmmscan and prints to screen the results
 
 Usage:
- python check_biorisk.py -i INPUT.biorisk.hmmscan -d databases/biorisk_db/ 
+ python check_biorisk.py -i INPUT.biorisk.hmmscan -d databases/biorisk_db/
 """
+
 import logging
 import os
+
 import pandas as pd
-from commec.config.query import Query
+
 from commec.config.constants import (
-    BIORISK_SHORT_QUERY_NT_THRESHOLD,
-    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
     BIORISK_LONG_QUERY_EVALUE_THRESHOLD,
+    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
+    BIORISK_SHORT_QUERY_NT_THRESHOLD,
 )
-from commec.tools.hmmer import (
-    readhmmer,
-    remove_overlaps,
-    recalculate_hmmer_query_coordinates,
-    append_nt_querylength_info,
-    HmmerHandler
-)
+from commec.config.query import Query
 from commec.config.result import (
-    ScreenResult,
     HitResult,
-    ScreenStep,
-    ScreenStatus,
     HitScreenStatus,
     MatchRange,
-    compare
+    ScreenResult,
+    ScreenStatus,
+    ScreenStep,
+    compare,
+)
+from commec.tools.hmmer import (
+    HmmerHandler,
+    append_nt_querylength_info,
+    readhmmer,
+    recalculate_hmmer_query_coordinates,
+    remove_overlaps,
 )
 
 logger = logging.getLogger(__name__)
 
-def _guess_domain(search_string : str) -> str:
-    """ 
-    Given a string description, try to determine 
+
+def _guess_domain(search_string: str) -> str:
+    """
+    Given a string description, try to determine
     which domain of life this has come from. Temporary work around
     until we can retrieve this data directly from biorisk outputs.
     """
-    def contains(search_string : str, search_terms):
+
+    def contains(search_string: str, search_terms):
         for token in search_terms:
             if search_string.find(token) == -1:
                 continue
@@ -49,25 +54,29 @@ def _guess_domain(search_string : str) -> str:
 
     search_token = search_string.lower()
     if contains(search_token, ["vir", "capsid", "RNA Polymerase"]):
-        logger.debug("Determined virus from \"%s\"", search_string)
+        logger.debug('Determined virus from "%s"', search_string)
         return "Virus"
-    if contains(search_token, ["cillus","bact","coccus","phila","ella","cocci","coli"]):
-        logger.debug("Determined bacteria from \"%s\"", search_string)
+    if contains(
+        search_token, ["cillus", "bact", "coccus", "phila", "ella", "cocci", "coli"]
+    ):
+        logger.debug('Determined bacteria from "%s"', search_string)
         return "Bacteria"
-    if contains(search_token, ["eukary","nucleus","sona","odium","myces"]):
-        logger.debug("Determined Eukaryote from \"%s\"", search_string)
+    if contains(search_token, ["eukary", "nucleus", "sona", "odium", "myces"]):
+        logger.debug('Determined Eukaryote from "%s"', search_string)
         return "Eukaryote"
-    logger.debug("Could not guess domain from \"%s\"", search_string)
+    logger.debug('Could not guess domain from "%s"', search_string)
     return "not assigned"
+
 
 def read_biorisk_annotations(hmm_folder_csv) -> pd.DataFrame:
     """
-    Import the biorisk annotations csv file, 
+    Import the biorisk annotations csv file,
     returns the file imported as a pandas DataFrame.
     """
-    lookup : pd.DataFrame = pd.read_csv(hmm_folder_csv)
+    lookup: pd.DataFrame = pd.read_csv(hmm_folder_csv)
     lookup.fillna(False, inplace=True)
     return lookup
+
 
 def biorisk_evalue_filter(hmmer: pd.DataFrame) -> pd.DataFrame:
     """
@@ -81,22 +90,25 @@ def biorisk_evalue_filter(hmmer: pd.DataFrame) -> pd.DataFrame:
     Returns a filtered copy of the input DataFrame.
     """
     df = hmmer.copy()
-    df['E-value'] = pd.to_numeric(df['E-value'], errors='coerce')
-    df['nt_qlen'] = pd.to_numeric(df['nt_qlen'], errors='coerce')
+    df["E-value"] = pd.to_numeric(df["E-value"], errors="coerce")
+    df["nt_qlen"] = pd.to_numeric(df["nt_qlen"], errors="coerce")
 
-    short_query = df['nt_qlen'] < BIORISK_SHORT_QUERY_NT_THRESHOLD
-    short_cutoff = 1 / (1 + df['nt_qlen'] ** BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+    short_query = df["nt_qlen"] < BIORISK_SHORT_QUERY_NT_THRESHOLD
+    short_cutoff = 1 / (1 + df["nt_qlen"] ** BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
 
-    mask = (short_query & (df['E-value'] < short_cutoff)) | \
-           (~short_query & (df['E-value'] < BIORISK_LONG_QUERY_EVALUE_THRESHOLD))
+    mask = (short_query & (df["E-value"] < short_cutoff)) | (
+        ~short_query & (df["E-value"] < BIORISK_LONG_QUERY_EVALUE_THRESHOLD)
+    )
 
     return df[mask]
 
 
-def parse_biorisk_hits(search_handler : HmmerHandler,
-                                      biorisk_annotations_file : str | os.PathLike,
-                                      data : ScreenResult,
-                                      queries : dict[str, Query]):
+def parse_biorisk_hits(
+    search_handler: HmmerHandler,
+    biorisk_annotations_file: str | os.PathLike,
+    data: ScreenResult,
+    queries: dict[str, Query],
+):
     """
     Takes an input database, reads its outputs, and updates the input data to contain
     biorisk hits from the database. Also requires passing of the biorisk annotations CSV file.
@@ -114,11 +126,14 @@ def parse_biorisk_hits(search_handler : HmmerHandler,
         logger.error("\t...biorisk_annotations.csv does not exist\n %s", hmm_folder_csv)
         return 1
     if not search_handler.validate_output():
-        logger.error("\t...database output file does not exist, or is empty\n %s", search_handler.out_file)
+        logger.error(
+            "\t...database output file does not exist, or is empty\n %s",
+            search_handler.out_file,
+        )
         return 1
 
     # We delay non-debug logging to sort messages via query.
-    log_container = {key : [] for key in data.queries.keys()}
+    log_container = {key: [] for key in data.queries.keys()}
 
     for query in data.queries.values():
         query.status.set_step_status(ScreenStep.BIORISK, ScreenStatus.PASS)
@@ -127,66 +142,97 @@ def parse_biorisk_hits(search_handler : HmmerHandler,
         return 0
 
     # Read in Output, and parse.
-    hmmer : pd.DataFrame = readhmmer(search_handler.out_file)
+    hmmer: pd.DataFrame = readhmmer(search_handler.out_file)
     logger.debug("Biorisk Import: shape: %s preview:\n%s", hmmer.shape, hmmer.head())
     append_nt_querylength_info(hmmer, queries)
-    logger.debug("Appended Query NT length: shape: %s preview:\n%s", 
-                 hmmer.shape, hmmer[["query name","nt_qlen"]].head())
+    logger.debug(
+        "Appended Query NT length: shape: %s preview:\n%s",
+        hmmer.shape,
+        hmmer[["query name", "nt_qlen"]].head(),
+    )
     hmmer = biorisk_evalue_filter(hmmer)
-    logger.debug("Biorisk Filterd by E-Value: shape: %s preview:\n%s", 
-                 hmmer.shape, hmmer.head())
+    logger.debug(
+        "Biorisk Filterd by E-Value: shape: %s preview:\n%s", hmmer.shape, hmmer.head()
+    )
     recalculate_hmmer_query_coordinates(hmmer)
-    logger.debug("Recalculated AA to NT coords: shape: %s preview:\n%s", 
-                 hmmer.shape, hmmer[["ali from","ali to","q. start","q. end"]].head())
+    logger.debug(
+        "Recalculated AA to NT coords: shape: %s preview:\n%s",
+        hmmer.shape,
+        hmmer[["ali from", "ali to", "q. start", "q. end"]].head(),
+    )
     hmmer = remove_overlaps(hmmer)
     logger.debug("Removed overlaps: shape: %s preview:\n%s", hmmer.shape, hmmer.head())
 
     lookup = read_biorisk_annotations(hmm_folder_csv)
 
     # Append description, and must_flag columns from annotations:
-    hmmer['description'] = ''
-    hmmer['Must flag'] = False
+    hmmer["description"] = ""
+    hmmer["Must flag"] = False
     hmmer = hmmer.reset_index(drop=True)
     for model in range(hmmer.shape[0]):
-        name_index = [i for i, x in enumerate([lookup['ID'] == hmmer['target name'][model]][0]) if x]
-        hmmer.loc[model, 'description'] = lookup.iloc[name_index[0], 1]
-        hmmer.loc[model, 'Must flag'] = lookup.iloc[name_index[0], 2]
+        name_index = [
+            i
+            for i, x in enumerate([lookup["ID"] == hmmer["target name"][model]][0])
+            if x
+        ]
+        hmmer.loc[model, "description"] = lookup.iloc[name_index[0], 1]
+        hmmer.loc[model, "Must flag"] = lookup.iloc[name_index[0], 2]
 
     # Update the data state to capture the outputs from biorisk search:
-    unique_queries = hmmer['query name'].unique()
-    logger.debug("Unique Queries: shape: %s preview:\n%s", unique_queries.shape, unique_queries)
+    unique_queries = hmmer["query name"].unique()
+    logger.debug(
+        "Unique Queries: shape: %s preview:\n%s", unique_queries.shape, unique_queries
+    )
     for affected_query in unique_queries:
         logger.debug("\tProcessing query: %s", affected_query)
-        biorisk_overall : ScreenStatus = ScreenStatus.PASS
+        biorisk_overall: ScreenStatus = ScreenStatus.PASS
 
         query_data = data.get_query(affected_query)
         if not query_data:
-            logger.error("Query during hmmscan could not be found! [%s]", affected_query)
+            logger.error(
+                "Query during hmmscan could not be found! [%s]", affected_query
+            )
             continue
 
         queries[affected_query[:-2]].mark_as_hit()
 
         # Grab a list of unique queries, and targets for iteration.
-        unique_query_data : pd.DataFrame = hmmer[hmmer['query name'] == affected_query]
-        unique_targets = unique_query_data['target name'].unique()
-        
-        logger.debug("\tData for %s: shape: %s preview:\n%s", 
-                     affected_query, unique_query_data.shape, unique_query_data.head())
-        logger.debug("\tTargets (%i) hit by %s: %s", 
-                     len(unique_targets), affected_query , unique_targets)
+        unique_query_data: pd.DataFrame = hmmer[hmmer["query name"] == affected_query]
+        unique_targets = unique_query_data["target name"].unique()
+
+        logger.debug(
+            "\tData for %s: shape: %s preview:\n%s",
+            affected_query,
+            unique_query_data.shape,
+            unique_query_data.head(),
+        )
+        logger.debug(
+            "\tTargets (%i) hit by %s: %s",
+            len(unique_targets),
+            affected_query,
+            unique_targets,
+        )
 
         for affected_target in unique_targets:
             logger.debug("\t\tProcessing target %s", affected_target)
-            unique_target_data = unique_query_data[unique_query_data['target name'] == affected_target]
-            target_description = ", ".join(set(unique_target_data['description'])) # First should be unique.
-            must_flag = unique_target_data['Must flag'].iloc[0] # First should be unique.
+            unique_target_data = unique_query_data[
+                unique_query_data["target name"] == affected_target
+            ]
+            target_description = ", ".join(
+                set(unique_target_data["description"])
+            )  # First should be unique.
+            must_flag = unique_target_data["Must flag"].iloc[
+                0
+            ]  # First should be unique.
             match_ranges = []
             match_string = ""
             for _, region in unique_target_data.iterrows():
                 match_range = MatchRange(
-                    float(region['E-value']),
-                    int(region['hmm from']), int(region['hmm to']),
-                    int(region['q. start']), int(region['q. end'])
+                    float(region["E-value"]),
+                    int(region["hmm from"]),
+                    int(region["hmm to"]),
+                    int(region["q. start"]),
+                    int(region["q. end"]),
                 )
                 match_ranges.append(match_range)
                 match_string += f"{match_range.query_start}-{match_range.query_end}, "
@@ -194,40 +240,47 @@ def parse_biorisk_hits(search_handler : HmmerHandler,
             # Remove final ", "
             match_string = match_string[:-2]
 
-            target_recommendation = ScreenStatus.FLAG if must_flag > 0 else ScreenStatus.WARN
-            logger.debug("\t\tTarget recommendation from this hit: %s", target_recommendation)
+            target_recommendation = (
+                ScreenStatus.FLAG if must_flag > 0 else ScreenStatus.WARN
+            )
+            logger.debug(
+                "\t\tTarget recommendation from this hit: %s", target_recommendation
+            )
 
             biorisk_overall = compare(target_recommendation, biorisk_overall)
 
             # Precalculate some logging information...
-            regulation_str : str = "Regulated Gene" if must_flag else "Virulence Factor"
-            log_message = f"\t --> {regulation_str} found at coordinates: {match_string}."
+            regulation_str: str = "Regulated Gene" if must_flag else "Virulence Factor"
+            log_message = (
+                f"\t --> {regulation_str} found at coordinates: {match_string}."
+            )
             logger.debug(f"{affected_query[:-2]:<25}" + log_message)
             log_container[affected_query[:-2]].append(log_message)
 
             # Deal with whether this biorisk should collapse into an existing hit or not.
-            hit_data : HitResult = query_data.get_hit(affected_target)
+            hit_data: HitResult = query_data.get_hit(affected_target)
             if hit_data:
-                logger.debug("\t\tHit already existed! Extending hit data ranges only...")
+                logger.debug(
+                    "\t\tHit already existed! Extending hit data ranges only..."
+                )
                 hit_data.ranges.extend(match_ranges)
                 logger.debug("Updated hit: %s", hit_data)
                 continue
 
-            domain : str = _guess_domain(""+str(affected_target)+target_description)
+            domain: str = _guess_domain("" + str(affected_target) + target_description)
 
-            new_hit : HitResult = HitResult(
-                HitScreenStatus(
-                    target_recommendation,
-                    ScreenStep.BIORISK
-                ),
+            new_hit: HitResult = HitResult(
+                HitScreenStatus(target_recommendation, ScreenStep.BIORISK),
                 affected_target,
                 target_description,
                 match_ranges,
-                {"domain" : [domain],"regulated":[regulation_str]},
+                {"domain": [domain], "regulated": [regulation_str]},
             )
-            logger.debug("\t\tHit was unique, creating new hit result information...\n%s", new_hit)
+            logger.debug(
+                "\t\tHit was unique, creating new hit result information...\n%s",
+                new_hit,
+            )
             query_data.hits[affected_target] = new_hit
-
 
         # Update the recommendation for this query for biorisk.
         query_data.status.set_step_status(ScreenStep.BIORISK, biorisk_overall)

--- a/commec/screeners/check_low_concern.py
+++ b/commec/screeners/check_low_concern.py
@@ -1,238 +1,361 @@
 #!/usr/bin/env python3
 # Copyright (c) 2021-2024 International Biosecurity and Biosafety Initiative for Science
 """
-Script that checks the output from 3 databases of low concern, deriving protein, 
-dna, and rna sources. Protein (hmmscan), rna (cmscan), and dna (blastn) are 
+Script that checks the output from 3 databases of low concern, deriving protein,
+dna, and rna sources. Protein (hmmscan), rna (cmscan), and dna (blastn) are
 checked via the entry point `parse_low_concern_hits``.
-The input dictionary of Query objects is updated in place with the resulting 
+The input dictionary of Query objects is updated in place with the resulting
 relevant low concern information.
 """
+
 import logging
+
 import pandas as pd
-from commec.tools.blast_tools import get_top_hits
-from commec.tools.blastn import BlastNHandler  # For has_hits.
-from commec.tools.hmmer import HmmerHandler
-from commec.tools.cmscan import CmscanHandler
+
 from commec.config.query import Query
-from commec.tools.hmmer import (
-    recalculate_hmmer_query_coordinates,
-    append_nt_querylength_info
-)
 from commec.config.result import (
     HitResult,
-    ScreenStep,
-    ScreenStatus,
     HitScreenStatus,
     MatchRange,
+    ScreenStatus,
+    ScreenStep,
+)
+from commec.tools.blast_tools import get_top_hits
+from commec.tools.blastn import BlastNHandler  # For has_hits.
+from commec.tools.cmscan import CmscanHandler
+from commec.tools.hmmer import (
+    HmmerHandler,
+    append_nt_querylength_info,
+    recalculate_hmmer_query_coordinates,
 )
 
 # Constants determining Commec's sensitivity for low_concern screen.
-LOW_CONCERN_PROTEIN_EVALUE_CUTOFF : float = 1e-20
-MINIMUM_PEPTIDE_COVERAGE : int = 50 # Number is counted in NTs, not AA's.
-MINIMUM_QUERY_COVERAGE_FRACTION : float = 0.80
-MINIMUM_RNA_BASEPAIR_COVERAGE : int = 50
-MINIMUM_SYNBIO_COVERAGE_FRACTION : float = 0.80
+LOW_CONCERN_PROTEIN_EVALUE_CUTOFF: float = 1e-20
+MINIMUM_PEPTIDE_COVERAGE: int = 50  # Number is counted in NTs, not AA's.
+MINIMUM_QUERY_COVERAGE_FRACTION: float = 0.80
+MINIMUM_RNA_BASEPAIR_COVERAGE: int = 50
+MINIMUM_SYNBIO_COVERAGE_FRACTION: float = 0.80
 
 logger = logging.getLogger(__name__)
 
-def _filter_low_concern_proteins(query : Query,
-                            hit : HitResult,
-                            region : MatchRange,
-                            low_concern_protein_for_query : pd.DataFrame,
-                            low_concern_descriptions : pd.DataFrame) -> list:
+
+def _filter_low_concern_proteins(
+    query: Query,
+    hit: HitResult,
+    region: MatchRange,
+    low_concern_protein_for_query: pd.DataFrame,
+    low_concern_descriptions: pd.DataFrame,
+) -> list:
     """
     Performs the logic of a low-concern housekeeping protein dataframe for a
-    specific query, and determines whether it contains the criteria to clear 
+    specific query, and determines whether it contains the criteria to clear
     a specified hit, for a specified region.
 
-    Benign proteins should have a coverage of at least 80% of the region they are 
+    Benign proteins should have a coverage of at least 80% of the region they are
     aiming to cover, as well as be at least 50 nucleotide in length.
     """
-    logger.debug("\t\t\tChecking query (%s) hit %s for proteins of low-concern",  query.name, hit.name)
+    logger.debug(
+        "\t\t\tChecking query (%s) hit %s for proteins of low-concern",
+        query.name,
+        hit.name,
+    )
 
     # Ignore this region, if there are no overlapping hits.
-    low_concern_protein_for_query_trimmed = _trim_to_region(low_concern_protein_for_query, region).copy()
+    low_concern_protein_for_query_trimmed = _trim_to_region(
+        low_concern_protein_for_query, region
+    ).copy()
     if low_concern_protein_for_query_trimmed.empty:
         logger.debug("\t\tNo overlapping Proteins of low-concern for %s", hit.name)
         return []
 
-    low_concern_protein_for_query_trimmed = _calculate_coverage(low_concern_protein_for_query_trimmed, region)
-    logger.debug("\tCoverage Data for %s: shape: %s preview:\n%s", 
-                     hit.name, low_concern_protein_for_query_trimmed.shape, 
-                     low_concern_protein_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head())
+    low_concern_protein_for_query_trimmed = _calculate_coverage(
+        low_concern_protein_for_query_trimmed, region
+    )
+    logger.debug(
+        "\tCoverage Data for %s: shape: %s preview:\n%s",
+        hit.name,
+        low_concern_protein_for_query_trimmed.shape,
+        low_concern_protein_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head(),
+    )
     # Ensure that this low_concern hit covers at least 50 nucleotides of the query
     low_concern_protein_for_query_trimmed = low_concern_protein_for_query_trimmed[
-        low_concern_protein_for_query_trimmed["coverage_nt"] > MINIMUM_PEPTIDE_COVERAGE]
+        low_concern_protein_for_query_trimmed["coverage_nt"] > MINIMUM_PEPTIDE_COVERAGE
+    ]
 
     if low_concern_protein_for_query_trimmed.empty:
-        logger.info("\t --> Insufficient coverage (<%i bp) for housekeeping protein to clear %s (%i-%i).",
-        int(MINIMUM_PEPTIDE_COVERAGE), hit.name, region.query_start, region.query_end)
+        logger.info(
+            "\t --> Insufficient coverage (<%i bp) for housekeeping protein to clear %s (%i-%i).",
+            int(MINIMUM_PEPTIDE_COVERAGE),
+            hit.name,
+            region.query_start,
+            region.query_end,
+        )
         return []
 
     # Ensure that this low_concern hit covers at least 80% of the regulated region.
     low_concern_protein_for_query_trimmed = low_concern_protein_for_query_trimmed[
-        low_concern_protein_for_query_trimmed["coverage_ratio"] > MINIMUM_QUERY_COVERAGE_FRACTION]
+        low_concern_protein_for_query_trimmed["coverage_ratio"]
+        > MINIMUM_QUERY_COVERAGE_FRACTION
+    ]
 
-    low_concern_protein_for_query_trimmed = low_concern_protein_for_query_trimmed.reset_index(drop=True)
+    low_concern_protein_for_query_trimmed = (
+        low_concern_protein_for_query_trimmed.reset_index(drop=True)
+    )
 
     if low_concern_protein_for_query_trimmed.empty:
-        logger.info("\t --> Insufficient coverage (<%i%%) for housekeeping protein to clear %s (%i-%i).",
-        int(MINIMUM_QUERY_COVERAGE_FRACTION*100), hit.name, region.query_start, region.query_end)
+        logger.info(
+            "\t --> Insufficient coverage (<%i%%) for housekeeping protein to clear %s (%i-%i).",
+            int(MINIMUM_QUERY_COVERAGE_FRACTION * 100),
+            hit.name,
+            region.query_start,
+            region.query_end,
+        )
         return []
 
     # Report top hit for Protein / RNA / Synbio
     low_concern_hit = low_concern_protein_for_query_trimmed["subject title"].iloc[0]
-    low_concern_hit_description = str(*low_concern_descriptions["Description"][low_concern_descriptions["ID"] == low_concern_hit])
+    low_concern_hit_description = str(
+        *low_concern_descriptions["Description"][
+            low_concern_descriptions["ID"] == low_concern_hit
+        ]
+    )
     match_ranges = [
         MatchRange(
-        float(low_concern_protein_for_query_trimmed['evalue'].iloc[0]),
-        int(low_concern_protein_for_query_trimmed['s. start'].iloc[0]), int(low_concern_protein_for_query_trimmed['s. end'].iloc[0]),
-        int(low_concern_protein_for_query_trimmed['q. start'].iloc[0]), int(low_concern_protein_for_query_trimmed['q. end'].iloc[0])
+            float(low_concern_protein_for_query_trimmed["evalue"].iloc[0]),
+            int(low_concern_protein_for_query_trimmed["s. start"].iloc[0]),
+            int(low_concern_protein_for_query_trimmed["s. end"].iloc[0]),
+            int(low_concern_protein_for_query_trimmed["q. start"].iloc[0]),
+            int(low_concern_protein_for_query_trimmed["q. end"].iloc[0]),
         )
     ]
     low_concern_hit_outcome = HitResult(
-            HitScreenStatus(
-                ScreenStatus.PASS,
-                ScreenStep.LOW_CONCERN_PROTEIN
-            ),
-            low_concern_hit,
-            low_concern_hit_description,
-            match_ranges,
-            annotations={"Coverage: ":float(low_concern_protein_for_query_trimmed['coverage_ratio'].iloc[0])}
-        )
+        HitScreenStatus(ScreenStatus.PASS, ScreenStep.LOW_CONCERN_PROTEIN),
+        low_concern_hit,
+        low_concern_hit_description,
+        match_ranges,
+        annotations={
+            "Coverage: ": float(
+                low_concern_protein_for_query_trimmed["coverage_ratio"].iloc[0]
+            )
+        },
+    )
 
     # Rarely, something can be cleared that is already cleared, no need to report on that.
-    if hit.recommendation.status not in {ScreenStatus.CLEARED_FLAG, ScreenStatus.CLEARED_WARN}:
-        logger.info("\t --> Clearing %s (%s) with house-keeping protein, %s",
-                        hit.name, hit.recommendation.status, low_concern_hit_outcome.name)
+    if hit.recommendation.status not in {
+        ScreenStatus.CLEARED_FLAG,
+        ScreenStatus.CLEARED_WARN,
+    }:
+        logger.info(
+            "\t --> Clearing %s (%s) with house-keeping protein, %s",
+            hit.name,
+            hit.recommendation.status,
+            low_concern_hit_outcome.name,
+        )
         hit.recommendation.status = hit.recommendation.status.clear()
         low_concern_hit_outcome.recommendation.status = hit.recommendation.status
 
     return [low_concern_hit_outcome]
 
-def _filter_low_concern_rna(query : Query,
-                            hit : HitResult,
-                            region : MatchRange,
-                            low_concern_rna_for_query : pd.DataFrame) -> list:
-    logger.debug("\t\t\tChecking query (%s) hit %s for RNA of low-concern",  query.name, hit.name)
-    
+
+def _filter_low_concern_rna(
+    query: Query,
+    hit: HitResult,
+    region: MatchRange,
+    low_concern_rna_for_query: pd.DataFrame,
+) -> list:
+    logger.debug(
+        "\t\t\tChecking query (%s) hit %s for RNA of low-concern", query.name, hit.name
+    )
+
     # Filter low_concern RNA for relevance...
-    low_concern_rna_for_query_trimmed = _trim_to_region(low_concern_rna_for_query, region).copy()
+    low_concern_rna_for_query_trimmed = _trim_to_region(
+        low_concern_rna_for_query, region
+    ).copy()
     if low_concern_rna_for_query_trimmed.empty:
-        logger.debug("\t\t\tNo overlapping low-concern RNA regions for %s (%i-%i)",
-                     hit.name, region.query_start, region.query_end)
+        logger.debug(
+            "\t\t\tNo overlapping low-concern RNA regions for %s (%i-%i)",
+            hit.name,
+            region.query_start,
+            region.query_end,
+        )
         return []
 
-    low_concern_rna_for_query_trimmed = _calculate_coverage(low_concern_rna_for_query_trimmed, region)
-    logger.debug("\t\t\tCoverage Data for %s: shape: %s preview:\n%s", 
-                     hit.name, low_concern_rna_for_query_trimmed.shape, 
-                     low_concern_rna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head())
-    
-    low_concern_rna_for_query_passed = low_concern_rna_for_query_trimmed[
-        (region.length() - low_concern_rna_for_query_trimmed["coverage_nt"]) < MINIMUM_RNA_BASEPAIR_COVERAGE]
-    low_concern_rna_for_query_passed = low_concern_rna_for_query_passed.reset_index(drop=True)
+    low_concern_rna_for_query_trimmed = _calculate_coverage(
+        low_concern_rna_for_query_trimmed, region
+    )
+    logger.debug(
+        "\t\t\tCoverage Data for %s: shape: %s preview:\n%s",
+        hit.name,
+        low_concern_rna_for_query_trimmed.shape,
+        low_concern_rna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head(),
+    )
 
-    logger.debug("\t\tSummary RNA of low-concern for %s: shape: %s preview:\n%s", 
-                hit.name, low_concern_rna_for_query_trimmed.shape,
-                low_concern_rna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head())
-    
+    low_concern_rna_for_query_passed = low_concern_rna_for_query_trimmed[
+        (region.length() - low_concern_rna_for_query_trimmed["coverage_nt"])
+        < MINIMUM_RNA_BASEPAIR_COVERAGE
+    ]
+    low_concern_rna_for_query_passed = low_concern_rna_for_query_passed.reset_index(
+        drop=True
+    )
+
+    logger.debug(
+        "\t\tSummary RNA of low-concern for %s: shape: %s preview:\n%s",
+        hit.name,
+        low_concern_rna_for_query_trimmed.shape,
+        low_concern_rna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head(),
+    )
+
     if not low_concern_rna_for_query_passed.empty:
         low_concern_hit = low_concern_rna_for_query_trimmed["subject title"].iloc[0]
-        low_concern_hit_description =  low_concern_rna_for_query_trimmed["description of target"].iloc[0]
+        low_concern_hit_description = low_concern_rna_for_query_trimmed[
+            "description of target"
+        ].iloc[0]
         match_ranges = [
             MatchRange(
-            float(low_concern_rna_for_query_trimmed['evalue'].iloc[0]),
-            int(low_concern_rna_for_query_trimmed['s. start'].iloc[0]), int(low_concern_rna_for_query_trimmed['s. end'].iloc[0]),
-            int(low_concern_rna_for_query_trimmed['q. start'].iloc[0]), int(low_concern_rna_for_query_trimmed['q. end'].iloc[0])
+                float(low_concern_rna_for_query_trimmed["evalue"].iloc[0]),
+                int(low_concern_rna_for_query_trimmed["s. start"].iloc[0]),
+                int(low_concern_rna_for_query_trimmed["s. end"].iloc[0]),
+                int(low_concern_rna_for_query_trimmed["q. start"].iloc[0]),
+                int(low_concern_rna_for_query_trimmed["q. end"].iloc[0]),
             )
         ]
         low_concern_hit_outcome = HitResult(
-                HitScreenStatus(
-                    ScreenStatus.PASS,
-                    ScreenStep.LOW_CONCERN_RNA
-                ),
-                low_concern_hit,
-                low_concern_hit_description,
-                match_ranges,
+            HitScreenStatus(ScreenStatus.PASS, ScreenStep.LOW_CONCERN_RNA),
+            low_concern_hit,
+            low_concern_hit_description,
+            match_ranges,
+        )
+
+        if hit.recommendation.status not in {
+            ScreenStatus.CLEARED_FLAG,
+            ScreenStatus.CLEARED_WARN,
+        }:
+            logger.info(
+                "\t --> Clearing %s %s (region %i-%i), with RNA of low-concern %s",
+                hit.recommendation.status,
+                hit.name,
+                region.query_start,
+                region.query_end,
+                low_concern_hit_outcome.name,
             )
-        
-        if hit.recommendation.status not in {ScreenStatus.CLEARED_FLAG, ScreenStatus.CLEARED_WARN}:
-            logger.info("\t --> Clearing %s %s (region %i-%i), with RNA of low-concern %s",
-                        hit.recommendation.status, hit.name, region.query_start, region.query_end, low_concern_hit_outcome.name)
             hit.recommendation.status = hit.recommendation.status.clear()
             low_concern_hit_outcome.recommendation.status = hit.recommendation.status
 
         return [low_concern_hit_outcome]
-    
-    logger.info("Clear failed for %s (%s) as RNA of low-concern has >%i bases unaccounted for.",
-                    hit.name, hit.recommendation.status, MINIMUM_RNA_BASEPAIR_COVERAGE)
+
+    logger.info(
+        "Clear failed for %s (%s) as RNA of low-concern has >%i bases unaccounted for.",
+        hit.name,
+        hit.recommendation.status,
+        MINIMUM_RNA_BASEPAIR_COVERAGE,
+    )
     return []
 
-def _filter_low_concern_dna(query : Query,
-                          hit : HitResult,
-                          region : MatchRange,
-                          low_concern_dna_for_query : pd.DataFrame) -> list:
-    logger.debug("\t\t\tChecking query (%s) hit %s for low-concern Synbio",  query.name, hit.name)
+
+def _filter_low_concern_dna(
+    query: Query,
+    hit: HitResult,
+    region: MatchRange,
+    low_concern_dna_for_query: pd.DataFrame,
+) -> list:
+    logger.debug(
+        "\t\t\tChecking query (%s) hit %s for low-concern Synbio", query.name, hit.name
+    )
 
     # Filter low_concern SynBio for relevance...
-    low_concern_dna_for_query_trimmed = _trim_to_region(low_concern_dna_for_query, region).copy()
+    low_concern_dna_for_query_trimmed = _trim_to_region(
+        low_concern_dna_for_query, region
+    ).copy()
     if low_concern_dna_for_query_trimmed.empty:
-        logger.debug("\t ... No overlapping low-concern DNA regions for %s (%i-%i)",
-                     hit.name, region.query_start, region.query_end)
+        logger.debug(
+            "\t ... No overlapping low-concern DNA regions for %s (%i-%i)",
+            hit.name,
+            region.query_start,
+            region.query_end,
+        )
         return []
 
-    low_concern_dna_for_query_trimmed = _calculate_coverage(low_concern_dna_for_query_trimmed, region)
-    logger.debug("\t\t\tCoverage Data for %s: shape: %s preview:\n%s", 
-                     hit.name, low_concern_dna_for_query_trimmed.shape, 
-                     low_concern_dna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head())
+    low_concern_dna_for_query_trimmed = _calculate_coverage(
+        low_concern_dna_for_query_trimmed, region
+    )
+    logger.debug(
+        "\t\t\tCoverage Data for %s: shape: %s preview:\n%s",
+        hit.name,
+        low_concern_dna_for_query_trimmed.shape,
+        low_concern_dna_for_query_trimmed[["coverage_nt", "coverage_ratio"]].head(),
+    )
 
     low_concern_dna_for_query_trimmed = low_concern_dna_for_query_trimmed[
-        low_concern_dna_for_query_trimmed["coverage_ratio"] > MINIMUM_SYNBIO_COVERAGE_FRACTION]
-    low_concern_dna_for_query_trimmed = low_concern_dna_for_query_trimmed.reset_index(drop=True)
-    logger.debug("\t\t\tFiltered Coverage Synbio for %s: shape: %s preview:\n%s",
-                     hit.name, low_concern_dna_for_query_trimmed.shape,
-                     low_concern_dna_for_query_trimmed.head())
+        low_concern_dna_for_query_trimmed["coverage_ratio"]
+        > MINIMUM_SYNBIO_COVERAGE_FRACTION
+    ]
+    low_concern_dna_for_query_trimmed = low_concern_dna_for_query_trimmed.reset_index(
+        drop=True
+    )
+    logger.debug(
+        "\t\t\tFiltered Coverage Synbio for %s: shape: %s preview:\n%s",
+        hit.name,
+        low_concern_dna_for_query_trimmed.shape,
+        low_concern_dna_for_query_trimmed.head(),
+    )
 
     if low_concern_dna_for_query_trimmed.empty:
-        logger.info("\t --> Synbio sequences <80%% coverage achieved over hit %s over %i-%i.",
-                        hit.name, region.query_start, region.query_end)
+        logger.info(
+            "\t --> Synbio sequences <80%% coverage achieved over hit %s over %i-%i.",
+            hit.name,
+            region.query_start,
+            region.query_end,
+        )
         return []
 
     low_concern_hit = low_concern_dna_for_query_trimmed["subject title"].iloc[0]
-    low_concern_hit_description =  low_concern_dna_for_query_trimmed["subject title"].iloc[0]
+    low_concern_hit_description = low_concern_dna_for_query_trimmed[
+        "subject title"
+    ].iloc[0]
     match_ranges = [
         MatchRange(
-        float(low_concern_dna_for_query_trimmed['evalue'].iloc[0]),
-        int(low_concern_dna_for_query_trimmed['s. start'].iloc[0]), int(low_concern_dna_for_query_trimmed['s. end'].iloc[0]),
-        int(low_concern_dna_for_query_trimmed['q. start'].iloc[0]), int(low_concern_dna_for_query_trimmed['q. end'].iloc[0])
+            float(low_concern_dna_for_query_trimmed["evalue"].iloc[0]),
+            int(low_concern_dna_for_query_trimmed["s. start"].iloc[0]),
+            int(low_concern_dna_for_query_trimmed["s. end"].iloc[0]),
+            int(low_concern_dna_for_query_trimmed["q. start"].iloc[0]),
+            int(low_concern_dna_for_query_trimmed["q. end"].iloc[0]),
         )
     ]
     low_concern_hit_outcome = HitResult(
-            HitScreenStatus(
-                ScreenStatus.PASS,
-                ScreenStep.LOW_CONCERN_DNA
-            ),
-            low_concern_hit,
-            low_concern_hit_description,
-            match_ranges,
-        )
-    
+        HitScreenStatus(ScreenStatus.PASS, ScreenStep.LOW_CONCERN_DNA),
+        low_concern_hit,
+        low_concern_hit_description,
+        match_ranges,
+    )
+
     logger.debug("Processing low-concern Hit: %s", low_concern_hit_outcome)
-    
-    if hit.recommendation.status not in {ScreenStatus.CLEARED_FLAG, ScreenStatus.CLEARED_WARN}:
-        logger.info("\t --> Clearing %s at bases (%i-%i) as low-concern DNA: \"%s\" matched synthetic biology part \"%s\"",
-                        hit.recommendation.status, region.query_start, region.query_end, hit.name, low_concern_hit_outcome.name)
+
+    if hit.recommendation.status not in {
+        ScreenStatus.CLEARED_FLAG,
+        ScreenStatus.CLEARED_WARN,
+    }:
+        logger.info(
+            '\t --> Clearing %s at bases (%i-%i) as low-concern DNA: "%s" matched synthetic biology part "%s"',
+            hit.recommendation.status,
+            region.query_start,
+            region.query_end,
+            hit.name,
+            low_concern_hit_outcome.name,
+        )
         hit.recommendation.status = hit.recommendation.status.clear()
         low_concern_hit_outcome.recommendation.status = hit.recommendation.status
     return [low_concern_hit_outcome]
 
-def _update_low_concern_data_for_query(query : Query,
-                                  low_concern_protein : pd.DataFrame,
-                                  low_concern_rna : pd.DataFrame,
-                                  low_concern_dna : pd.DataFrame,
-                                  low_concern_descriptions : pd.DataFrame):
+
+def _update_low_concern_data_for_query(
+    query: Query,
+    low_concern_protein: pd.DataFrame,
+    low_concern_rna: pd.DataFrame,
+    low_concern_dna: pd.DataFrame,
+    low_concern_descriptions: pd.DataFrame,
+):
     """
-    For a single query, look at all three low_concern database outputs, and update the 
+    For a single query, look at all three low_concern database outputs, and update the
     single queries hit descriptions to record all the low_concern hits, as well as clear
     any overlapping WARN or FLAG hits.
     """
@@ -270,14 +393,19 @@ def _update_low_concern_data_for_query(query : Query,
     # Check every region, of every hit that is a FLAG or WARN, against the Benign screen outcomes.
     for hit in query.result.hits.values():
         # Ignore regions that don't require clearing...
-        if (hit.recommendation.status not in {
-            ScreenStatus.FLAG,
-            ScreenStatus.WARN
-            }):
-            logger.debug("\t\t\tIgnoring %s [%s], nothing to clear.", hit.name, hit.recommendation.status)
+        if hit.recommendation.status not in {ScreenStatus.FLAG, ScreenStatus.WARN}:
+            logger.debug(
+                "\t\t\tIgnoring %s [%s], nothing to clear.",
+                hit.name,
+                hit.recommendation.status,
+            )
             continue
-        if (hit.recommendation.from_step == ScreenStep.BIORISK):
-            logger.debug("\t\t\tIgnoring %s [%s], cannot clear from Biorisk step.", hit.name, hit.recommendation.status)
+        if hit.recommendation.from_step == ScreenStep.BIORISK:
+            logger.debug(
+                "\t\t\tIgnoring %s [%s], cannot clear from Biorisk step.",
+                hit.name,
+                hit.recommendation.status,
+            )
             continue
 
         cleared_regions = 0
@@ -285,38 +413,51 @@ def _update_low_concern_data_for_query(query : Query,
         logger.debug("Hit has %i regions required to clear.", total_regions_to_clear)
 
         for region in hit.ranges:
-
             if not low_concern_protein_for_query.empty:
                 query.mark_as_hit()
-                low_concern_proteins = _filter_low_concern_proteins(query, hit, region,
-                                            low_concern_protein_for_query,
-                                            low_concern_descriptions)
+                low_concern_proteins = _filter_low_concern_proteins(
+                    query,
+                    hit,
+                    region,
+                    low_concern_protein_for_query,
+                    low_concern_descriptions,
+                )
                 if low_concern_proteins:
                     cleared_regions += 1
                     new_low_concern_protein_hits.extend(low_concern_proteins)
-            
+
             if not low_concern_rna_for_query.empty:
                 query.mark_as_hit()
-                low_concern_rna = _filter_low_concern_rna(query, hit, region,
-                                       low_concern_rna_for_query)
+                low_concern_rna = _filter_low_concern_rna(
+                    query, hit, region, low_concern_rna_for_query
+                )
                 if low_concern_rna:
                     cleared_regions += 1
                     new_low_concern_rna_hits.extend(low_concern_rna)
-                
+
             if not low_concern_dna_for_query.empty:
                 query.mark_as_hit()
-                low_concern_dna = _filter_low_concern_dna(query, hit, region,
-                                          low_concern_dna_for_query)
+                low_concern_dna = _filter_low_concern_dna(
+                    query, hit, region, low_concern_dna_for_query
+                )
                 if low_concern_dna:
                     cleared_regions += 1
                     new_low_concern_dna_hits.extend(low_concern_dna)
 
         # Quickly check if this hit had all regions cleared.
         if cleared_regions >= total_regions_to_clear:
-            logger.debug("Cleared %i / %i regions. This hit is cleared.", cleared_regions, total_regions_to_clear)
+            logger.debug(
+                "Cleared %i / %i regions. This hit is cleared.",
+                cleared_regions,
+                total_regions_to_clear,
+            )
             hit.recommendation.status.clear()
         else:
-            logger.debug("Only cleared %i/%i regions. This hit was not cleared.", cleared_regions, total_regions_to_clear)
+            logger.debug(
+                "Only cleared %i/%i regions. This hit was not cleared.",
+                cleared_regions,
+                total_regions_to_clear,
+            )
             hit.recommendation.status = hit.recommendation.status.revert_clear()
 
     # Report Query Specific lack of hits.
@@ -336,17 +477,20 @@ def _update_low_concern_data_for_query(query : Query,
         query.result.add_new_hit_information(low_concern_addition)
         logger.debug("\t\tAdding low-concern Hit: %s", low_concern_addition)
 
-def parse_low_concern_hits(protein_handler : HmmerHandler,
-                            rna_handler : CmscanHandler,
-                            dna_handler : BlastNHandler,
-                            queries : dict[str,Query],
-                            low_concern_desc : pd.DataFrame):
+
+def parse_low_concern_hits(
+    protein_handler: HmmerHandler,
+    rna_handler: CmscanHandler,
+    dna_handler: BlastNHandler,
+    queries: dict[str, Query],
+    low_concern_desc: pd.DataFrame,
+):
     """
     Parses the outputs from protein (HMMER), RNA (CMSCAN), and DNA (BLASTN) low-concern screens.
 
     This function processes hit data from the respective handlers, and updates each query's result handle with
-    low-concern status information based on these outcomes. 
-    Queries with no relevant flagged or warned hits are marked as SKIP. 
+    low-concern status information based on these outcomes.
+    Queries with no relevant flagged or warned hits are marked as SKIP.
     ----
     ## Parameters:
     * `protein_handler` (HmmerHandler): Handler for HMMER-based protein search results.
@@ -362,55 +506,62 @@ def parse_low_concern_hits(protein_handler : HmmerHandler,
     low_concern_protein_screen_data = protein_handler.read_output()
     append_nt_querylength_info(low_concern_protein_screen_data, queries)
     recalculate_hmmer_query_coordinates(low_concern_protein_screen_data)
-    logger.debug("\tLow-concern Protein Data: shape: %s preview:\n%s",
-                 low_concern_protein_screen_data.shape, low_concern_protein_screen_data.head())
-    
+    logger.debug(
+        "\tLow-concern Protein Data: shape: %s preview:\n%s",
+        low_concern_protein_screen_data.shape,
+        low_concern_protein_screen_data.head(),
+    )
+
     low_concern_rna_screen_data = rna_handler.read_output()
-    logger.debug("\tLow-concern RNA Data: shape: %s preview:\n%s",
-                low_concern_rna_screen_data.shape, low_concern_rna_screen_data.head())
-    
+    logger.debug(
+        "\tLow-concern RNA Data: shape: %s preview:\n%s",
+        low_concern_rna_screen_data.shape,
+        low_concern_rna_screen_data.head(),
+    )
+
     low_concern_dna_screen_data = dna_handler.read_output()
     low_concern_dna_screen_data = get_top_hits(low_concern_dna_screen_data)
-    logger.debug("\tLow-concern Synbio Top Hits Data: shape: %s preview:\n%s",
-                low_concern_dna_screen_data.shape, low_concern_dna_screen_data.head())
-    
-    for query in queries.values():
+    logger.debug(
+        "\tLow-concern Synbio Top Hits Data: shape: %s preview:\n%s",
+        low_concern_dna_screen_data.shape,
+        low_concern_dna_screen_data.head(),
+    )
 
+    for query in queries.values():
         skip = True
         for hit in query.result.hits.values():
-            if hit.recommendation.status in {
-                ScreenStatus.FLAG,
-                ScreenStatus.WARN
-            }:
+            if hit.recommendation.status in {ScreenStatus.FLAG, ScreenStatus.WARN}:
                 skip = False
 
         if skip:
             query.result.status.low_concern = ScreenStatus.SKIP
-        
+
         if query.result.status.low_concern == ScreenStatus.SKIP:
-            logger.debug("Skipping query %s, no regulated regions to clear.", query.name)
+            logger.debug(
+                "Skipping query %s, no regulated regions to clear.", query.name
+            )
             continue
-        
-        _update_low_concern_data_for_query(query,
-                                      low_concern_protein_screen_data,
-                                      low_concern_rna_screen_data,
-                                      low_concern_dna_screen_data,
-                                      low_concern_desc)
+
+        _update_low_concern_data_for_query(
+            query,
+            low_concern_protein_screen_data,
+            low_concern_rna_screen_data,
+            low_concern_dna_screen_data,
+            low_concern_desc,
+        )
 
         # Calculate the Benign Screen outcomes for each query.
         query.result.status.low_concern = ScreenStatus.PASS
         # If any hits are still warnings, or flags, propagate that to the low_concern step.
         for flagged_hit in query.result.get_flagged_hits():
             query.result.status.update_step_status(
-               ScreenStep.LOW_CONCERN_DNA, flagged_hit.recommendation.status
-        )
+                ScreenStep.LOW_CONCERN_DNA, flagged_hit.recommendation.status
+            )
 
-def _trim_to_region(data : pd.DataFrame, region : MatchRange):
+
+def _trim_to_region(data: pd.DataFrame, region: MatchRange):
     datatrim = data[
-        ~(
-            (data["q. start"] > region.query_end)
-            & (data["q. end"] > region.query_end)
-        )
+        ~((data["q. start"] > region.query_end) & (data["q. end"] > region.query_end))
         & ~(
             (data["q. start"] < region.query_start)
             & (data["q. end"] < region.query_start)
@@ -418,14 +569,14 @@ def _trim_to_region(data : pd.DataFrame, region : MatchRange):
     ]
     return datatrim
 
-def _calculate_coverage(data : pd.DataFrame, region : MatchRange):
-    """ 
-    Mutates data to add coverage compared to a specific region, 
+
+def _calculate_coverage(data: pd.DataFrame, region: MatchRange):
+    """
+    Mutates data to add coverage compared to a specific region,
     as a ratio and absolute number of nucleotides.
     """
-    data.loc[:,"coverage_nt"] = (
-        data["q. end"].clip(upper=region.query_end) - 
-        data["q. start"].clip(lower=region.query_start)
-        )
-    data.loc[:,"coverage_ratio"] = data["coverage_nt"] / region.length()
+    data.loc[:, "coverage_nt"] = data["q. end"].clip(upper=region.query_end) - data[
+        "q. start"
+    ].clip(lower=region.query_start)
+    data.loc[:, "coverage_ratio"] = data["coverage_nt"] / region.length()
     return data

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -8,55 +8,64 @@ Usage:
   python check_reg_path.py -i INPUT -d database_folder -t threads
 
 """
+
 import logging
 import os
 from dataclasses import asdict
 
 import pandas as pd
-from commec.tools.search_handler import SearchHandler
+
 from commec.config.query import Query
-from commec.tools.blast_tools import (
-    read_blast,
-    get_lineages,
-    get_taxonomic_labels,
-    get_top_hits
-)
 from commec.config.result import (
-    ScreenResult,
-    TaxonomyAnnotation,
     HitResult,
-    ScreenStep,
-    ScreenStatus,
     HitScreenStatus,
     MatchRange,
-    compare
+    ScreenResult,
+    ScreenStatus,
+    ScreenStep,
+    TaxonomyAnnotation,
+    compare,
 )
+from commec.tools.blast_tools import (
+    get_lineages,
+    get_taxonomic_labels,
+    get_top_hits,
+    read_blast,
+)
+from commec.tools.search_handler import SearchHandler
 
 pd.set_option("display.max_colwidth", 10000)
 
 logger = logging.getLogger(__name__)
 
+
 def _check_inputs(
-        search_handler : SearchHandler,
-        low_concern_taxid_path : str | os.PathLike,
-        biorisk_taxid_path : str | os.PathLike,
-        taxonomy_directory : str | os.PathLike
-        ):
-    """ 
-    Simply check for the existance of files, 
-    returns True if it is safe to continue. 
+    search_handler: SearchHandler,
+    low_concern_taxid_path: str | os.PathLike,
+    biorisk_taxid_path: str | os.PathLike,
+    taxonomy_directory: str | os.PathLike,
+):
+    """
+    Simply check for the existance of files,
+    returns True if it is safe to continue.
     """
     # check input files
     if not search_handler.validate_output():
-        logger.info("\t...ERROR: Taxonomic search results empty\n %s", search_handler.out_file)
+        logger.info(
+            "\t...ERROR: Taxonomic search results empty\n %s", search_handler.out_file
+        )
         return False
 
     if not os.path.exists(low_concern_taxid_path):
-        logger.error("\t...low-concern database file %s does not exist\n", low_concern_taxid_path)
+        logger.error(
+            "\t...low-concern database file %s does not exist\n", low_concern_taxid_path
+        )
         return False
 
     if not os.path.exists(biorisk_taxid_path):
-        logger.error("\t...biorisk database file %s does not exist\n", biorisk_taxid_path)
+        logger.error(
+            "\t...biorisk database file %s does not exist\n", biorisk_taxid_path
+        )
         return False
 
     if not os.path.exists(taxonomy_directory):
@@ -65,7 +74,10 @@ def _check_inputs(
 
     return True
 
-def get_canonical_taxids(taxids: pd.Series, db_path: str | os.PathLike, threads: int) -> list[str]:
+
+def get_canonical_taxids(
+    taxids: pd.Series, db_path: str | os.PathLike, threads: int
+) -> list[str]:
     """
     Retrieve the current canonical taxids to handle NCBI taxonomy updates.
     """
@@ -75,15 +87,15 @@ def get_canonical_taxids(taxids: pd.Series, db_path: str | os.PathLike, threads:
 
 
 def parse_taxonomy_hits(
-        search_handler : SearchHandler,
-        low_concern_taxid_path : str | os.PathLike,
-        biorisk_taxid_path : str | os.PathLike,
-        taxonomy_directory : str | os.PathLike,
-        data : ScreenResult,
-        queries : dict[str, Query],
-        step : ScreenStep,
-        n_threads : int
-        ):
+    search_handler: SearchHandler,
+    low_concern_taxid_path: str | os.PathLike,
+    biorisk_taxid_path: str | os.PathLike,
+    taxonomy_directory: str | os.PathLike,
+    data: ScreenResult,
+    queries: dict[str, Query],
+    step: ScreenStep,
+    n_threads: int,
+):
     """
     Given a Taxonomic database screen output, update the screen data appropriately.
         search_handler : The handle of the search tool used to screen taxonomic data.
@@ -97,26 +109,29 @@ def parse_taxonomy_hits(
 
     def unique_annotation_set(df) -> set[TaxonomyAnnotation]:
         """
-        Convenience function to extract taxonomy annotations into a 
+        Convenience function to extract taxonomy annotations into a
         common structure, from BLAST results with the appropriate column headings.
         """
         return {
             TaxonomyAnnotation(*row)
-            for row in df[[
-                "evalue",
-                "subject tax ids",
-                "species",
-                "genus",
-                "superkingdom",
-                "subject acc.",
-                "subject title",
-            ]].itertuples(index=False, name=None)
+            for row in df[
+                [
+                    "evalue",
+                    "subject tax ids",
+                    "species",
+                    "genus",
+                    "superkingdom",
+                    "subject acc.",
+                    "subject title",
+                ]
+            ].itertuples(index=False, name=None)
         }
-    
+
     logger.debug("Acquiring Taxonomic Data for JSON output:")
 
-    if not _check_inputs(search_handler, low_concern_taxid_path,
-                         biorisk_taxid_path, taxonomy_directory):
+    if not _check_inputs(
+        search_handler, low_concern_taxid_path, biorisk_taxid_path, taxonomy_directory
+    ):
         return 1
 
     # The default is to pass, its up to the data to over-write this.
@@ -128,7 +143,7 @@ def parse_taxonomy_hits(
         return 0
 
     # We delay non-debug logging to sort messages via query.
-    log_container = {key : [] for key in data.queries.keys()}
+    log_container = {key: [] for key in data.queries.keys()}
 
     # Read in lists of regulated and low_concern tax ids
     vax_taxids = get_canonical_taxids(
@@ -143,36 +158,56 @@ def parse_taxonomy_hits(
     )
 
     blast = read_blast(search_handler.out_file)
-    logger.debug("%s Blast Import: shape: %s preview:\n%s", step, blast.shape, blast.head())
+    logger.debug(
+        "%s Blast Import: shape: %s preview:\n%s", step, blast.shape, blast.head()
+    )
 
     # Initial check for query to be identified as anything known.
-    unique_queries = blast['query acc.'].unique()
+    unique_queries = blast["query acc."].unique()
     for query_acc in unique_queries:
         query_obj = queries.get(query_acc)
         if query_obj:
             logger.debug("Confirming hits for query %s.", query_acc)
             query_obj.mark_as_hit()
         else:
-            logger.error("Could not mark query %s for confirmation of hit, "
-                            "query not found in input queries.", query_acc)
+            logger.error(
+                "Could not mark query %s for confirmation of hit, "
+                "query not found in input queries.",
+                query_acc,
+            )
 
     # Add taxonomic labels, and filter synthetic constructs
-    blast = get_taxonomic_labels(blast, reg_taxids, vax_taxids, taxonomy_directory, n_threads)
-    logger.debug("%s TaxLabels: shape: %s preview:\n%s", step, blast.shape, blast.head())
+    blast = get_taxonomic_labels(
+        blast, reg_taxids, vax_taxids, taxonomy_directory, n_threads
+    )
+    logger.debug(
+        "%s TaxLabels: shape: %s preview:\n%s", step, blast.shape, blast.head()
+    )
 
-    blast = blast[blast["species"] != ""]  # ignore submissions made above the species level
-    logger.debug("%s RemoveSpecies: shape: %s preview:\n%s", step, blast.shape, blast.head())
+    blast = blast[
+        blast["species"] != ""
+    ]  # ignore submissions made above the species level
+    logger.debug(
+        "%s RemoveSpecies: shape: %s preview:\n%s", step, blast.shape, blast.head()
+    )
 
     # label each base with the top matching hit, but include different taxids attributed to same hit
     top_hits = get_top_hits(blast)
-    logger.debug("%s Top Hits: shape: %s preview:\n%s", step, top_hits.shape, top_hits.head())
+    logger.debug(
+        "%s Top Hits: shape: %s preview:\n%s", step, top_hits.shape, top_hits.head()
+    )
 
     if top_hits["regulated"].sum() == 0:
         logger.info("\t...no regulated hits\n")
         return 0
 
-    unique_queries = top_hits['query acc.'].unique()
-    logger.debug("%s Unique Queries: shape: %s preview:\n%s", step, unique_queries.shape, unique_queries)
+    unique_queries = top_hits["query acc."].unique()
+    logger.debug(
+        "%s Unique Queries: shape: %s preview:\n%s",
+        step,
+        unique_queries.shape,
+        unique_queries,
+    )
     for query in unique_queries:
         logger.debug("\tProcessing query: %s", query)
         query_write = data.get_query(query)
@@ -180,29 +215,39 @@ def parse_taxonomy_hits(
             logger.error("Query during %s could not be found! [%s]", str(step), query)
             continue
 
-        unique_query_data : pd.DataFrame = top_hits[top_hits['query acc.'] == query]
-        unique_query_data.dropna(subset = ['species'])
+        unique_query_data: pd.DataFrame = top_hits[top_hits["query acc."] == query]
+        unique_query_data.dropna(subset=["species"])
         regulated_only_data = unique_query_data[unique_query_data["regulated"] == True]
-        regulated_hits = regulated_only_data['subject acc.'].unique()
-        logger.debug("\t%s Regulated hits: shape: %s preview:\n%s",
-                     step, regulated_hits.shape, regulated_hits)
+        regulated_hits = regulated_only_data["subject acc."].unique()
+        logger.debug(
+            "\t%s Regulated hits: shape: %s preview:\n%s",
+            step,
+            regulated_hits.shape,
+            regulated_hits,
+        )
 
         for hit in regulated_hits:
             logger.debug("\t\tProcessing Hit: %s", hit)
-            regulated_hit_data : pd.DataFrame = regulated_only_data[regulated_only_data["subject acc."] == hit]
-            hit_name = regulated_hit_data['subject title'].values[0]
-            logger.debug("%s Regulated Hit Data: shape: %s preview:\n%s",
-                         step, regulated_hit_data.shape, regulated_hit_data.head())
+            regulated_hit_data: pd.DataFrame = regulated_only_data[
+                regulated_only_data["subject acc."] == hit
+            ]
+            hit_name = regulated_hit_data["subject title"].values[0]
+            logger.debug(
+                "%s Regulated Hit Data: shape: %s preview:\n%s",
+                step,
+                regulated_hit_data.shape,
+                regulated_hit_data.head(),
+            )
 
             n_regulated_bacteria = 0
             n_regulated_virus = 0
             n_regulated_eukaryote = 0
-            
-            reg_taxids = [] # Regulated Taxonomy IDS
-            non_reg_taxids = [] # Non-regulated Taxonomy IDS.
-            reg_species = [] # List of species
-            domains = [] # List of domains.
-            match_ranges = [] # Ranges where hit matches query.
+
+            reg_taxids = []  # Regulated Taxonomy IDS
+            non_reg_taxids = []  # Non-regulated Taxonomy IDS.
+            reg_species = []  # List of species
+            domains = []  # List of domains.
+            match_ranges = []  # Ranges where hit matches query.
 
             regulated_annotations = set()
             non_regulated_annotations = set()
@@ -210,73 +255,89 @@ def parse_taxonomy_hits(
             for _, region in regulated_hit_data.iterrows():
                 # Record region information:
                 match_range = MatchRange(
-                    float(region['evalue']),
-                    int(region['s. start']), int(region['s. end']),
-                    int(region['q. start']), int(region['q. end'])
+                    float(region["evalue"]),
+                    int(region["s. start"]),
+                    int(region["s. end"]),
+                    int(region["q. start"]),
+                    int(region["q. end"]),
                 )
 
                 # Convert from non-coding to nt query coordinates if we're doing a NT taxonomy step.
                 if step == ScreenStep.TAXONOMY_NT:
-                    match_range.query_start = queries[query].nc_to_nt_query_coords(match_range.query_start)
-                    match_range.query_end = queries[query].nc_to_nt_query_coords(match_range.query_end)
+                    match_range.query_start = queries[query].nc_to_nt_query_coords(
+                        match_range.query_start
+                    )
+                    match_range.query_end = queries[query].nc_to_nt_query_coords(
+                        match_range.query_end
+                    )
                 match_ranges.append(match_range)
                 logger.debug("Processing region from hit: %s", region)
 
                 # Record domain information.
-                domain = region['superkingdom']
+                domain = region["superkingdom"]
                 if domain == "Viruses":
                     n_regulated_virus += 1
                     logger.debug("\t\t\tAdded Virus.")
                 if domain == "Bacteria":
-                    n_regulated_bacteria +=1
+                    n_regulated_bacteria += 1
                     logger.debug("\t\t\tAdded Bacteria.")
                 if domain == "Eukaryota":
-                    n_regulated_eukaryote+=1
+                    n_regulated_eukaryote += 1
                     logger.debug("\t\t\tAdded Eukaryote.")
                 domains.append(domain)
 
                 # Filter shared_site based on 'q. start' or 'q. end'
                 # (Previously only shared starts were used)
                 shared_site = unique_query_data[
-                    (unique_query_data['q. start'] == region['q. start']) |
-                    (unique_query_data['q. end'] == region['q. end'])
-                    ]
+                    (unique_query_data["q. start"] == region["q. start"])
+                    | (unique_query_data["q. end"] == region["q. end"])
+                ]
 
                 # Filter for regulated and non-regulated entries
                 regulated_for_region = shared_site[shared_site["regulated"] == True]
                 non_regulated_for_region = (
                     shared_site[shared_site["regulated"] == False]
                     .sort_values(by="evalue", ascending=True)
-                    .head(10) # we only care for max 10 non-regulated.
+                    .head(10)  # we only care for max 10 non-regulated.
                 )
 
                 # Optimise for conciseness by unique TaxID
-                regulated_for_region = regulated_for_region.drop_duplicates(subset=["subject tax ids"], keep="first")
-                non_regulated_for_region = non_regulated_for_region.drop_duplicates(subset=["subject tax ids"], keep="first")
+                regulated_for_region = regulated_for_region.drop_duplicates(
+                    subset=["subject tax ids"], keep="first"
+                )
+                non_regulated_for_region = non_regulated_for_region.drop_duplicates(
+                    subset=["subject tax ids"], keep="first"
+                )
 
                 # Collect unique species from both regulated and non-regulated - legacy logg
                 reg_species.extend(regulated_for_region["species"])
 
                 # JSON serialization requires int, not np.int64, hence the map()
                 reg_taxids.extend(map(str, regulated_for_region["subject tax ids"]))
-                non_reg_taxids.extend(map(str, non_regulated_for_region["subject tax ids"]))
+                non_reg_taxids.extend(
+                    map(str, non_regulated_for_region["subject tax ids"])
+                )
 
-
-                regulated_annotations = regulated_annotations | unique_annotation_set(regulated_for_region)
-                non_regulated_annotations = non_regulated_annotations | unique_annotation_set(non_regulated_for_region)
+                regulated_annotations = regulated_annotations | unique_annotation_set(
+                    regulated_for_region
+                )
+                non_regulated_annotations = (
+                    non_regulated_annotations
+                    | unique_annotation_set(non_regulated_for_region)
+                )
 
             # Convert our structures to a dictionary for JSON export, sorted by taxid.
             regulated_annotation_list = [asdict(t) for t in regulated_annotations]
-            non_regulated_annotation_list = [asdict(t) for t in non_regulated_annotations]
+            non_regulated_annotation_list = [
+                asdict(t) for t in non_regulated_annotations
+            ]
             regulated_annotation_list = sorted(
-                regulated_annotation_list,
-                key=lambda d: d["taxid"]
+                regulated_annotation_list, key=lambda d: d["taxid"]
             )
             non_regulated_annotation_list = sorted(
-                non_regulated_annotation_list,
-                key=lambda d: d["taxid"]
+                non_regulated_annotation_list, key=lambda d: d["taxid"]
             )
- 
+
             # Set the default hit description, this is changed if result is mixed etc.
             domains_text = ", ".join(set(domains))
             hit_description = f"Regulated {domains_text} - {regulated_hit_data['subject title'].values[0]}"
@@ -287,39 +348,43 @@ def parse_taxonomy_hits(
             # if all hits are in the same genus n_reg > 0, and n_total > n_reg, WARN, or other logic.
             # the point is, this is where you do it.
 
-            screen_status : ScreenStatus = ScreenStatus.FLAG # Default is to flag.
+            screen_status: ScreenStatus = ScreenStatus.FLAG  # Default is to flag.
 
-            logger.debug("Checking number of non regulated taxids: %i", len(non_regulated_annotation_list))
+            logger.debug(
+                "Checking number of non regulated taxids: %i",
+                len(non_regulated_annotation_list),
+            )
             if len(non_regulated_annotation_list) > 0:
                 logger.debug("Non-regulated taxids present, treating as MIXED result.")
                 screen_status = ScreenStatus.PASS
-                hit_description = (f"Mix of {len(regulated_annotation_list)} regulated {domains_text}"
-                f" and {len(non_regulated_annotation_list)} non-regulated {domains_text}")
+                hit_description = (
+                    f"Mix of {len(regulated_annotation_list)} regulated {domains_text}"
+                    f" and {len(non_regulated_annotation_list)} non-regulated {domains_text}"
+                )
 
             # Update the query level recommendation of this step.
             query_write.status.update_step_status(step, screen_status)
 
-            regulation_dict = {"number_of_regulated_taxids" : str(len(regulated_annotation_list)),
-                                "number_of_unregulated_taxids" : str(len(non_regulated_annotation_list)),
-                                "regulated_eukaryotes": str(n_regulated_eukaryote),
-                                "regulated_bacteria": str(n_regulated_bacteria),
-                                "regulated_viruses": str(n_regulated_virus),
-                                "regulated_taxa": regulated_annotation_list,
-                                "non_regulated_taxa" : non_regulated_annotation_list}
-            
+            regulation_dict = {
+                "number_of_regulated_taxids": str(len(regulated_annotation_list)),
+                "number_of_unregulated_taxids": str(len(non_regulated_annotation_list)),
+                "regulated_eukaryotes": str(n_regulated_eukaryote),
+                "regulated_bacteria": str(n_regulated_bacteria),
+                "regulated_viruses": str(n_regulated_virus),
+                "regulated_taxa": regulated_annotation_list,
+                "non_regulated_taxa": non_regulated_annotation_list,
+            }
+
             # Ensure each match range is unique.
             match_ranges = list(set(match_ranges))
 
             # Append our hit information to Screen data.
             new_hit = HitResult(
-                HitScreenStatus(
-                    screen_status,
-                    step
-                ),
+                HitScreenStatus(screen_status, step),
                 hit_name,
                 hit_description,
                 match_ranges,
-                {"domain" : [domain],"regulated_taxonomy":[regulation_dict]},
+                {"domain": [domain], "regulated_taxonomy": [regulation_dict]},
             )
 
             if query_write.add_new_hit_information(new_hit):
@@ -328,12 +393,14 @@ def parse_taxonomy_hits(
                     write_hit.ranges.extend(match_ranges)
                     write_hit.annotations["domain"] = domains
                     write_hit.annotations["regulated_taxonomy"].append(regulation_dict)
-                    write_hit.recommendation.status = compare(write_hit.recommendation.status, screen_status)
-                    write_hit.description += ","+hit_description
+                    write_hit.recommendation.status = compare(
+                        write_hit.recommendation.status, screen_status
+                    )
+                    write_hit.description += "," + hit_description
 
             logger.debug("Hit information summary: %s", new_hit)
 
-            # Logging logic - somewhat convolutedly placed but for the intention of recreating 
+            # Logging logic - somewhat convolutedly placed but for the intention of recreating
             # legacy-like .screen.log file logging experience.
             reg_species = list(set(reg_species))
             reg_taxids = list(set(reg_taxids))
@@ -342,13 +409,17 @@ def parse_taxonomy_hits(
             reg_species.sort()
             reg_taxids.sort()
             non_reg_taxids.sort()
-            
+
             reg_species_text = ", ".join(reg_species)
             reg_taxids_text = ", ".join(reg_taxids)
             non_reg_taxids_text = ", ".join(non_reg_taxids)
-            match_ranges_text = ", ".join(map(str,match_ranges))
+            match_ranges_text = ", ".join(map(str, match_ranges))
 
-            alt_text = "only " if screen_status == ScreenStatus.FLAG else "both regulated and non-"
+            alt_text = (
+                "only "
+                if screen_status == ScreenStatus.FLAG
+                else "both regulated and non-"
+            )
             s = "" if len(reg_taxids) == 1 else "'s"
             ss = "" if len(non_reg_taxids) == 1 else "'s"
             log_message = (
@@ -365,7 +436,6 @@ def parse_taxonomy_hits(
             logger.debug("\t\tRanges: %s", match_ranges)
 
             log_container[query].append(log_message)
-
 
     # Do all non-verbose logging in order of query:
     for query_name, log_list in log_container.items():

--- a/commec/setup.py
+++ b/commec/setup.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 # Copyright (c) 2021-2024 International Biosecurity and Biosafety Initiative for Science
 """
-Module for CLI setup of Commec, such that required 
+Module for CLI setup of Commec, such that required
 databases are downloaded in a desired database directory.
 """
-import sys
+
+import argparse
+import ftplib
+import json
 import os
 import shutil
-import argparse
 import subprocess
-from pathlib import Path
-import ftplib
-from urllib import request, error, parse
-import zipfile
+import sys
 import tarfile
+import zipfile
+from pathlib import Path
+from urllib import error, parse, request
+
 import yaml
-import json
 from yaml.parser import ParserError
 
 from commec.config.constants import DEFAULT_CONFIG_YAML_PATH
@@ -23,11 +25,12 @@ from commec.config.constants import DEFAULT_CONFIG_YAML_PATH
 DESCRIPTION = """Helper script for downloading the databases
  required for running the Common Mechanism Screen"""
 
-C_F_ORANGE = "\033[38;5;202m" # Colour Foreground Orange.
-C_F_GRAY = "\033[38;5;242m" # Colour Foreground Gray
-C_F_BLUE = "\033[38;5;17m" # Colour Foreground Blue
-C_B_BLUE = "\033[48;5;17m" # Colour Background Blue
-C_RESET = "\033[0m" # Reset Console Formatting.
+C_F_ORANGE = "\033[38;5;202m"  # Colour Foreground Orange.
+C_F_GRAY = "\033[38;5;242m"  # Colour Foreground Gray
+C_F_BLUE = "\033[38;5;17m"  # Colour Foreground Blue
+C_B_BLUE = "\033[48;5;17m"  # Colour Background Blue
+C_RESET = "\033[0m"  # Reset Console Formatting.
+
 
 class CliSetup:
     """
@@ -64,9 +67,13 @@ class CliSetup:
 
         self.download_biorisk: bool = True
         self.default_biorisk_download_url: str = (
-            "https://github.com/ibbis-bio/commec-databases/releases"
-            f"/download/{self.latest_version}/commec-dbs.zip"
-        ) if self.latest_version else ""
+            (
+                "https://github.com/ibbis-bio/commec-databases/releases"
+                f"/download/{self.latest_version}/commec-dbs.zip"
+            )
+            if self.latest_version
+            else ""
+        )
         self.biorisk_download_url: str = self.default_biorisk_download_url
 
         self.download_blastnr: bool = False
@@ -122,7 +129,7 @@ class CliSetup:
             "\n\nThis setup is split over 3 steps:",
             "\n 1. Specify download location.",
             "\n 2. Choose which databases to download.",
-            "\n 3. Confirm and start downloads."
+            "\n 3. Confirm and start downloads.",
         )
         self.print_help_info()
         print()
@@ -141,7 +148,9 @@ class CliSetup:
             " Instructions: "
             '\n -> You can exit this setup at any time with "exit"'
             '\n -> You can return to a previous step with "back"'
-            '\n -> You can get additional help at each step with "help"' + add_help_str + C_RESET
+            '\n -> You can get additional help at each step with "help"'
+            + add_help_str
+            + C_RESET
         )
 
     def check_requirements(self):
@@ -164,14 +173,17 @@ class CliSetup:
         if missing_deps:
             print(
                 f"{C_F_ORANGE}Required dependencies missing: "
-                + ", ".join(missing_deps) + C_RESET
+                + ", ".join(missing_deps)
+                + C_RESET
             )
-            print(f"{C_F_ORANGE}Check these are installed in your environment.{C_RESET}")
+            print(
+                f"{C_F_ORANGE}Check these are installed in your environment.{C_RESET}"
+            )
             self.stop()
 
     def check_directory_is_writable(self, input_directory: str) -> str:
         """
-        Checks a directory is viable by 
+        Checks a directory is viable by
         * Expanding terminal variables, user, and resolving the full path and
         * Checking if it exists or
         * Creating it and destroying it.
@@ -184,30 +196,34 @@ class CliSetup:
         # Catches accidental ~/commec-dbs/ vs ~commec-dbs/ when theres no commec-dbs username.
         try:
             path = path.expanduser()
-        except(RuntimeError):
-            print("User expansion for path failed, ensure you are using"
-                  " \"~/\" for self, or a valid user with \"~username/\".")
+        except RuntimeError:
+            print(
+                "User expansion for path failed, ensure you are using"
+                ' "~/" for self, or a valid user with "~username/".'
+            )
             return ""
 
         try:
             path = path.resolve()
-        except(RuntimeError):
+        except RuntimeError:
             return ""
 
         print(path)
         if path.exists():
             return path
-        
+
         if path.is_reserved():
             print("This path contains reserved characters for this Operating System.")
             return ""
-        
+
         # Handily, all sorts of special characters are identified with a %XX, within posix, and are replaced
         # by similar characters during mkdir, whilst technically legal, lets recommend against cursed dir names.
-        if '%' in path.as_posix():
-            print("Please avoid using special characters (\"|}{\":?><*&\" etc) in filepath names.")
+        if "%" in path.as_posix():
+            print(
+                'Please avoid using special characters ("|}{":?><*&" etc) in filepath names.'
+            )
             return ""
-    
+
         # If the path doesn't exist, the best way to know if user input is valid, is to try make it.
         # Find the part of the directory which is new, so we can delete only it after.
         path_to_remove_dirs = Path(path.parts[0])
@@ -265,9 +281,9 @@ class CliSetup:
 
     def decide_commec_dbs(self):
         """Decide whether the Commec Biorisks and low-concern databases need to be downloaded."""
-        self.print_step_header(2,1)
+        self.print_step_header(2, 1)
         print(
-            "Do you want to download the " "mandatory Commec databases? (~1.2 GB)",
+            "Do you want to download the mandatory Commec databases? (~1.2 GB)",
             '\n"y" or "n", for yes or no.',
         )
         while True:
@@ -327,8 +343,7 @@ class CliSetup:
             if not self.check_url_exists(self.biorisk_download_url):
                 print(
                     self.biorisk_download_url,
-                    " is not a valid URL! "
-                    "(or you are not connected to the internet)",
+                    " is not a valid URL! (or you are not connected to the internet)",
                 )
                 continue
 
@@ -338,7 +353,7 @@ class CliSetup:
 
     def decide_blastnr(self):
         """Decide whether a Protein database needs to be downloaded."""
-        self.print_step_header(2,3)
+        self.print_step_header(2, 3)
         print(
             "Do you want to download the"
             " protein NR database for protein screening? (~530 GB)",
@@ -374,7 +389,7 @@ class CliSetup:
 
     def decide_blastnt(self):
         """Decide what Nucleotide database needs to be downloaded."""
-        self.print_step_header(2,4)
+        self.print_step_header(2, 4)
         print(
             "Do you want to download the Nucleotide NT databases for non-coding"
             " region nucleotide screening? (~580 GB)",
@@ -387,7 +402,7 @@ class CliSetup:
                     [
                         "\n -> type yes,y or no,n to indicate decision.",
                         "\n   (The Blast Nucleotide database is used to screen",
-                        '\n   non-coding regions of queries, unless the user specifies to skip taxonomy or nt search,'
+                        "\n   non-coding regions of queries, unless the user specifies to skip taxonomy or nt search,"
                         "\n   and is around 580 GB in size.)",
                     ]
                 )
@@ -407,7 +422,7 @@ class CliSetup:
 
     def decide_taxonomy(self):
         """Decide whether taxonomy database need to be downloaded."""
-        self.print_step_header(2,5)
+        self.print_step_header(2, 5)
         print(
             "Do you want to download the Taxonomy databases? ( less than ~500 MB)",
             '\n"y" or "n", for yes or no.',
@@ -471,8 +486,7 @@ class CliSetup:
             if not self.check_url_exists(self.taxonomy_download_url):
                 print(
                     self.taxonomy_download_url,
-                    " is not a valid URL! "
-                    "(or you are not connected to the internet)",
+                    " is not a valid URL! (or you are not connected to the internet)",
                 )
                 continue
 
@@ -500,7 +514,7 @@ class CliSetup:
             print(" -> Nucleotide database will be downloaded.")
         if self.download_taxonomy:
             print(
-                " -> Taxonomy database will be downloaded," "\n    from URL: ",
+                " -> Taxonomy database will be downloaded,\n    from URL: ",
                 self.taxonomy_download_url,
             )
 
@@ -648,7 +662,9 @@ class CliSetup:
 
         # Default config file installed with commec package should by point to the newly
         # installed databases
-        self.update_default_db_base_path(DEFAULT_CONFIG_YAML_PATH, self.database_directory)
+        self.update_default_db_base_path(
+            DEFAULT_CONFIG_YAML_PATH, self.database_directory
+        )
 
         print(
             "\n\nThe common mechanism setup has completed!"
@@ -721,20 +737,22 @@ class CliSetup:
         where the databases were installed.
         """
         try:
-            with open(config_file, 'r', encoding = "utf-8") as file:
+            with open(config_file, "r", encoding="utf-8") as file:
                 config_data = yaml.safe_load(file)
 
             # Update the default path under 'base_paths'
-            if 'base_paths' in config_data and 'default' in config_data['base_paths']:
-                config_data['base_paths']['default'] = new_path
+            if "base_paths" in config_data and "default" in config_data["base_paths"]:
+                config_data["base_paths"]["default"] = new_path
             else:
                 # For some reason this didn't exist, so lets just silently make it, and throw a warning.
-                print(f"{C_F_ORANGE}WARNING: base paths weren't defined in the default configuration file "
-                      f"{config_file}, the correct data will be added, however we recommend you double "
-                      "check that the default config yaml is correct. {C_RESET}")
-                config_data['base_paths'] = {'default' : new_path}
+                print(
+                    f"{C_F_ORANGE}WARNING: base paths weren't defined in the default configuration file "
+                    f"{config_file}, the correct data will be added, however we recommend you double "
+                    "check that the default config yaml is correct. {C_RESET}"
+                )
+                config_data["base_paths"] = {"default": new_path}
 
-            with open(config_file, 'w', encoding = "utf-8") as file:
+            with open(config_file, "w", encoding="utf-8") as file:
                 yaml.safe_dump(config_data, file)
 
         except FileNotFoundError:
@@ -769,7 +787,10 @@ class CliSetup:
         print(f"{C_RESET}\nExiting setup for The Common Mechanism.")
         sys.exit()
 
-def get_latest_commec_database_release_tag(repo="ibbis-bio/commec-databases") -> tuple[str | None, str]:
+
+def get_latest_commec_database_release_tag(
+    repo="ibbis-bio/commec-databases",
+) -> tuple[str | None, str]:
     """
     Contacts GitHub for the latest tagged release of the commec databases.
     This can be used to compare to a local commec-db-version.txt file,
@@ -799,7 +820,7 @@ def get_latest_commec_database_release_tag(repo="ibbis-bio/commec-databases") ->
                 return None, f"GitHub API error: HTTP {response.status}"
             data = json.loads(response.read().decode())
         if "tag_name" in data:
-            return data.get("tag_name"), "Success" 
+            return data.get("tag_name"), "Success"
         else:
             return None, "Unexpected response structure: 'tag_name' not found."
     except error.HTTPError as e:

--- a/commec/setup.py
+++ b/commec/setup.py
@@ -674,7 +674,7 @@ class CliSetup:
             except error.URLError as e:
                 # Handle URL errors (like unreachable server, etc.)
                 print(f"URL Error: {e.reason}")
-            except ValueError as e:
+            except ValueError:
                 print(
                     "URL Value Error. It is likely the URL input"
                     " is not a recognized URL format."

--- a/commec/split.py
+++ b/commec/split.py
@@ -4,12 +4,15 @@
 Split a multi-record FASTA file into individual files, one for each record.
 
 Command-line usage:
-    split.py input.fasta 
+    split.py input.fasta
 """
+
 import argparse
 import os
 import string
+
 from Bio import SeqIO
+
 from commec.utils.file_utils import file_arg
 
 VALID_FILENAME_CHARS = f"-._{string.ascii_letters}{string.digits}"

--- a/commec/tests/screen_factory.py
+++ b/commec/tests/screen_factory.py
@@ -9,17 +9,18 @@ This abstracts the difficulty in dealing with external database files,
 as well as dealing with the various regulated annotations etc.
 """
 
-import os
-import math
 import json
+import math
+import os
 from dataclasses import asdict
 from unittest.mock import patch
 
 import pandas as pd
 
-from commec.screen import run, ScreenArgumentParser, add_args
-from commec.config.result import ScreenResult, ScreenStep
 from commec.config.json_io import get_screen_data_from_json
+from commec.config.result import ScreenResult, ScreenStep
+from commec.screen import ScreenArgumentParser, add_args, run
+
 
 def skip_taxonomy_info(
     blast: pd.DataFrame,
@@ -29,11 +30,12 @@ def skip_taxonomy_info(
     _threads: int,
 ):
     """
-    Override the taxonomy database retrieval with our own information at a 
+    Override the taxonomy database retrieval with our own information at a
     per-hit basis.
     """
-    blast = blast.merge(TAXONOMY, on = "subject acc.", how = "left")
+    blast = blast.merge(TAXONOMY, on="subject acc.", how="left")
     return blast
+
 
 def skip_biorisk_annotations(_input_file):
     """
@@ -42,6 +44,7 @@ def skip_biorisk_annotations(_input_file):
     """
     return BIORISK_ANNOTATIONS_DATA
 
+
 def skip_canonical_taxids(taxids, _db_path, _threads):
     """
     Override canonical taxid retrieval, so tests
@@ -49,23 +52,28 @@ def skip_canonical_taxids(taxids, _db_path, _threads):
     """
     return taxids.astype(str).tolist()
 
+
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
-TAXONOMY = pd.DataFrame(columns=["subject acc.","regulated", "superkingdom", "phylum", "genus", "species"])
+TAXONOMY = pd.DataFrame(
+    columns=["subject acc.", "regulated", "superkingdom", "phylum", "genus", "species"]
+)
 BIORISK_ANNOTATIONS_DATA = pd.DataFrame(columns=["ID", "Description", "Must flag"])
+
 
 class ScreenTesterFactory:
     """
     Factory class, to easily create the data for a commec screen run,
     so we can more easily construct various testing scenarios without bloated
     code strings.
-    Simply create an instance, and call 
+    Simply create an instance, and call
         add_query, : Add queries to the screen
         add_hit,    : Add hits to the screen
         add_regulated_taxid, : Include informatiokn as to what taxids are regulated.
-    
+
     and then run(), which will return the ScreenResult object.
 
     """
+
     def __init__(self, test_name, tmp_path):
         # Containers to hold input hits.
         self.name = test_name
@@ -81,8 +89,19 @@ class ScreenTesterFactory:
         self.input_fasta_path = ""
 
         # We reset the globals when a new test is made - its just safer.
-        TAXONOMY = pd.DataFrame(columns=["subject acc.","regulated", "superkingdom", "phylum", "genus", "species"])
-        BIORISK_ANNOTATIONS_DATA = pd.DataFrame(columns=["ID", "Description", "Must flag"])
+        TAXONOMY = pd.DataFrame(
+            columns=[
+                "subject acc.",
+                "regulated",
+                "superkingdom",
+                "phylum",
+                "genus",
+                "species",
+            ]
+        )
+        BIORISK_ANNOTATIONS_DATA = pd.DataFrame(
+            columns=["ID", "Description", "Must flag"]
+        )
 
     def run(self, *args):
         """
@@ -92,33 +111,48 @@ class ScreenTesterFactory:
         self._create_temporary_files()
 
         arguments = [
-                "test.py", str(self.input_fasta_path), 
-                "-d", str(DATABASE_DIRECTORY), 
-                "-o", str(self.tmp_path), 
-                "--resume",
-                "--verbose"
-            ]
-        
+            "test.py",
+            str(self.input_fasta_path),
+            "-d",
+            str(DATABASE_DIRECTORY),
+            "-o",
+            str(self.tmp_path),
+            "--resume",
+            "--verbose",
+        ]
+
         arguments.extend(args)
 
         print("Using the following Taxonomy Information:\n", TAXONOMY.to_string())
         # We patch taxonomic labels to avoid having to make a mini-taxonomy database.
         # We also patch in the desired CLI arguments to avoid an input yaml, and control output.
-        with (patch("commec.screeners.check_reg_path.get_taxonomic_labels", new=skip_taxonomy_info), patch(
-                "commec.screeners.check_biorisk.read_biorisk_annotations", new=skip_biorisk_annotations), patch(
-                "commec.screeners.check_reg_path.get_canonical_taxids", new=skip_canonical_taxids), patch(
-            "sys.argv",
-            arguments,
-        )):
+        with (
+            patch(
+                "commec.screeners.check_reg_path.get_taxonomic_labels",
+                new=skip_taxonomy_info,
+            ),
+            patch(
+                "commec.screeners.check_biorisk.read_biorisk_annotations",
+                new=skip_biorisk_annotations,
+            ),
+            patch(
+                "commec.screeners.check_reg_path.get_canonical_taxids",
+                new=skip_canonical_taxids,
+            ),
+            patch(
+                "sys.argv",
+                arguments,
+            ),
+        ):
             parser = ScreenArgumentParser()
             add_args(parser)
             args = parser.parse_args()
             run(args)
-        
+
         # return the screen data output for checking:
         json_output_path = self.tmp_path / f"{self.name}.output.json"
         assert os.path.isfile(json_output_path)
-        actual_screen_result : ScreenResult = get_screen_data_from_json(json_output_path)
+        actual_screen_result: ScreenResult = get_screen_data_from_json(json_output_path)
 
         print(f"Raw {self.name} test output: ")
         print(json.dumps(asdict(actual_screen_result), indent=2))
@@ -126,25 +160,26 @@ class ScreenTesterFactory:
         return actual_screen_result
 
     def add_query(self, name, size):
-        self.queries[name] = "a"*size
+        self.queries[name] = "a" * size
 
-    def add_hit(self,
-        to_step,                    # Which step this hit belongs to...
-        to_query,                   # Which query this hit belongs to...
-        start,                      # Start Nucleotide in Query coords.
-        stop,                       # End Nucleotide in Query Coords...
-        title = "untitled",
-        accession = "",
-        taxid = 0,
-        species = "unclassified",
-        genus = "unclassified",
-        superkingdom = "unclassified",
-        phylum = "unclassified",
-        regulated = False,          # Used to update taxonomy, and also biorisk Must flag.
-        score = 1000,               # Used for HMMSCAN
-        evalue = 0.0,               # can affect order.
-        description = "no description",
-        ):
+    def add_hit(
+        self,
+        to_step,  # Which step this hit belongs to...
+        to_query,  # Which query this hit belongs to...
+        start,  # Start Nucleotide in Query coords.
+        stop,  # End Nucleotide in Query Coords...
+        title="untitled",
+        accession="",
+        taxid=0,
+        species="unclassified",
+        genus="unclassified",
+        superkingdom="unclassified",
+        phylum="unclassified",
+        regulated=False,  # Used to update taxonomy, and also biorisk Must flag.
+        score=1000,  # Used for HMMSCAN
+        evalue=0.0,  # can affect order.
+        description="no description",
+    ):
 
         assert start > 0
         assert stop > 0
@@ -157,11 +192,11 @@ class ScreenTesterFactory:
                 superkingdom,
                 phylum,
                 genus,
-                species
+                species,
             ]
 
         query_length = len(self.queries[to_query])
-        query_length_aa = math.floor(query_length/3)
+        query_length_aa = math.floor(query_length / 3)
         # Calculate frame if appropriate:
         frame = (start - 1) % 3 + 1
         if start > stop:
@@ -176,16 +211,19 @@ class ScreenTesterFactory:
 
         start_aa = math.floor(start / 3)
         end_aa = math.floor(stop / 3)
-        
+
         # Used if HMMSCAN i.e. protein based.
         query_name = f"{to_query}_{str(frame)}"
 
         length = abs(stop - start)
         length_aa = abs(end_aa - start_aa)
-        
+
         if to_step == ScreenStep.BIORISK:
             BIORISK_ANNOTATIONS_DATA.loc[len(BIORISK_ANNOTATIONS_DATA)] = [
-                title, description, regulated]
+                title,
+                description,
+                regulated,
+            ]
             print(f"Added Biorisk Annotation: {title},{description},{regulated}")
             self.biorisks.append(
                 f"{title}\t{accession}\t{length_aa}\t{query_name}\t999\t{query_length_aa}\t{evalue}\t{score}\t10.0\t1\t1\t0\t0\t{score}\t10.0\t1\t{length_aa}\t{start_aa}\t{end_aa}\t1\t{length_aa}\t1.00\t{description}"
@@ -197,7 +235,7 @@ class ScreenTesterFactory:
                 f"{to_query}\t{title}\t{accession}\t{taxid}\t{evalue}\tBITSCORE\t99.999\t{query_length}\t{start}\t{stop}\t{length}\t1\t{length}"
             )
             return
-        
+
         if to_step == ScreenStep.TAXONOMY_NT:
             self.nucl_tx.append(
                 f"{to_query}\t{title}\t{accession}\t{taxid}\t{evalue}\tBITSCORE\t99.999\t{query_length}\t{start}\t{stop}\t{length}\t1\t{length}"
@@ -214,12 +252,12 @@ class ScreenTesterFactory:
             self.lowconcern_rna.append(
                 f"{title}\t{accession}\t{to_query}\tQA999\t{length}\t1\t{length}\t{start}\t{stop}\tSTRAND\tTRUNC\tPASS\tGC\t10\t{score}\t{evalue}\t100\t{description}"
             )
-            #RNA, mdl = target, seq = query
-            #"""\
-            #target name         accession query name                accession mdl mdl from   mdl to seq from   seq to strand trunc pass   gc  bias  score   E-value  inc description of target
-            #------------------- --------- ------------------------- --------- --- -------- -------- -------- -------- ------ ----- ---- ---- ----- ------ ---------  --- ---------------------
-            #BENIGNRNA            12346     FCTEST1	                 Q1         50	    100      200       50      150 STRAND TRUNC PASS   GC    10   1000       0.0  100    BenignCMTestOutput
-            #"""
+            # RNA, mdl = target, seq = query
+            # """\
+            # target name         accession query name                accession mdl mdl from   mdl to seq from   seq to strand trunc pass   gc  bias  score   E-value  inc description of target
+            # ------------------- --------- ------------------------- --------- --- -------- -------- -------- -------- ------ ----- ---- ---- ----- ------ ---------  --- ---------------------
+            # BENIGNRNA            12346     FCTEST1	                 Q1         50	    100      200       50      150 STRAND TRUNC PASS   GC    10   1000       0.0  100    BenignCMTestOutput
+            # """
             return
 
         if to_step == ScreenStep.LOW_CONCERN_DNA:
@@ -228,13 +266,12 @@ class ScreenTesterFactory:
             )
             return
 
-
     def _create_temporary_files(self):
-        
+
         # Make the paths.
         os.mkdir(self.tmp_path / f"output_{self.name}")
         os.mkdir(self.tmp_path / f"input_{self.name}")
-        
+
         # Create input fasta:
         self.input_fasta_path = self.tmp_path / f"{self.name}.fasta"
         print("Using fasta file: " + str(self.input_fasta_path))
@@ -247,7 +284,9 @@ class ScreenTesterFactory:
         # --RESUME FILES::
         # BIORISK FILES
         header = "#tname    accession  tlen qname        accession   qlen   E-value  score  bias   #  of  c-Evalue  i-Evalue  score  bias  from    to  from    to  from    to  acc description of target\n"
-        biorisk_db_output_path = self.tmp_path / f"output_{self.name}/{self.name}.biorisk.hmmscan"
+        biorisk_db_output_path = (
+            self.tmp_path / f"output_{self.name}/{self.name}.biorisk.hmmscan"
+        )
         hmmer_biorisk_to_parse = header + "\n".join(self.biorisks)
         biorisk_db_output_path.write_text(hmmer_biorisk_to_parse)
         print("writing biorisk hmm: \n", hmmer_biorisk_to_parse)
@@ -267,20 +306,25 @@ class ScreenTesterFactory:
 
         # LOW CONCERN FILES:
         header = " #tname    accession        tlen qname        accession   qlen   E-value  score  bias   #  of  c-Evalue  i-Evalue  score  bias    from    to  from    to  from    to  acc description of target\n"
-        low_concern_hmm_output_path = self.tmp_path / f"output_{self.name}/{self.name}.low_concern.hmmscan"
+        low_concern_hmm_output_path = (
+            self.tmp_path / f"output_{self.name}/{self.name}.low_concern.hmmscan"
+        )
         low_concern_hmmscan_to_parse = header + "\n".join(self.lowconcern_protein)
         low_concern_hmm_output_path.write_text(low_concern_hmmscan_to_parse)
         print("writing lowconcern hmm: \n", low_concern_hmmscan_to_parse)
 
         header = "#target name         accession query name                accession mdl mdl from   mdl to seq from   seq to strand trunc pass   gc  bias  score   E-value  inc description of target\n"
-        low_concern_cmscan_output_path = self.tmp_path / f"output_{self.name}/{self.name}.low_concern.cmscan"
+        low_concern_cmscan_output_path = (
+            self.tmp_path / f"output_{self.name}/{self.name}.low_concern.cmscan"
+        )
         low_concern_cmscan_to_parse = header + "\n".join(self.lowconcern_rna)
         low_concern_cmscan_output_path.write_text(low_concern_cmscan_to_parse)
         print("writing lowconcern rna: \n", low_concern_cmscan_to_parse)
 
         header = "#query acc.	title	subject acc.taxid	evalue	bit score	% identity	    q.len	q.start	q.end	    s.len	s. start	s. end\n"
-        low_concern_nt_output_path = self.tmp_path / f"output_{self.name}/{self.name}.low_concern.blastn"
+        low_concern_nt_output_path = (
+            self.tmp_path / f"output_{self.name}/{self.name}.low_concern.blastn"
+        )
         low_concern_blastnt_to_parse = header + "\n".join(self.lowconcern_dna)
         low_concern_nt_output_path.write_text(low_concern_blastnt_to_parse)
         print("writing lowconcern dna: \n", low_concern_blastnt_to_parse)
-

--- a/commec/tests/test_aa_to_nt.py
+++ b/commec/tests/test_aa_to_nt.py
@@ -8,18 +8,21 @@ The following behaviour is expected:
 """
 
 import pandas as pd
-from pandas.testing import assert_frame_equal
 import pytest
+from pandas.testing import assert_frame_equal
+
 from commec.tools.hmmer import recalculate_hmmer_query_coordinates
 
 # Example DataFrame
-example_hmmer_01 = pd.DataFrame({
-    "query name": ["F1","F2","F3","R1","R2", "R3"],
-    "frame":    [1,2,3,4,5,6],
-    "ali from": [1, 2, 3, 1, 2, 3],
-    "ali to":   [4, 5, 6, 4, 5, 6],
-    "nt_qlen":     [31, 31, 31, 31, 31, 31]
-})
+example_hmmer_01 = pd.DataFrame(
+    {
+        "query name": ["F1", "F2", "F3", "R1", "R2", "R3"],
+        "frame": [1, 2, 3, 4, 5, 6],
+        "ali from": [1, 2, 3, 1, 2, 3],
+        "ali to": [4, 5, 6, 4, 5, 6],
+        "nt_qlen": [31, 31, 31, 31, 31, 31],
+    }
+)
 
 # Logically, we would expect this to match Fwd and Rev all frame AA to NT coordinates:
 # 1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
@@ -30,8 +33,8 @@ example_hmmer_01 = pd.DataFrame({
 #       [  9  ]  [  8  ] [   7  ] [   6  ] [   5  ] [   4  ] [   3  ] [   2  ] [   1  ]
 #    [  9  ]  [  8  ] [   7  ] [   6  ] [   5  ] [   4  ] [   3  ] [   2  ] [   1  ] [  -1  ]
 
-# However, HMMER Biorisk behaves like the following 
-#(According to testing with BBa_I766605 YopH-EE under medium constitutive promotor, and reverse complements.)
+# However, HMMER Biorisk behaves like the following
+# (According to testing with BBa_I766605 YopH-EE under medium constitutive promotor, and reverse complements.)
 # 1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
 # [  1  ]  [  2  ]  [  3  ] [   4  ] [   5  ] [   6  ] [   7  ] [   8  ] [   9  ] [  10  ]
 #    [  1  ]  [  2  ]  [  3  ] [   4  ] [   5  ] [   6  ] [   7  ] [   8  ] [   9  ] [  10  ]
@@ -41,41 +44,43 @@ example_hmmer_01 = pd.DataFrame({
 #          [  9  ]  [  8  ] [   7  ] [   6  ] [   5  ] [   4  ] [   3  ] [   2  ] [   1  ] [  -1  ]
 
 # Example DataFrame
-original_expected_output = pd.DataFrame({
-    "query name": ["F1","F2","F3","R1","R2", "R3"],
-    "frame":    [1,2,3,4,5,6],
-    "ali from": [1, 2, 3, 1, 2, 3],
-    "ali to":   [4, 5, 6, 4, 5, 6],
-    "nt_qlen":  [31, 31, 31, 31, 31, 31],
-    "q. start": [ 1,  5,  9,  19,  15, 11],
-    "q. end":   [12, 16, 20,  30,  26, 22]
-})
+original_expected_output = pd.DataFrame(
+    {
+        "query name": ["F1", "F2", "F3", "R1", "R2", "R3"],
+        "frame": [1, 2, 3, 4, 5, 6],
+        "ali from": [1, 2, 3, 1, 2, 3],
+        "ali to": [4, 5, 6, 4, 5, 6],
+        "nt_qlen": [31, 31, 31, 31, 31, 31],
+        "q. start": [1, 5, 9, 19, 15, 11],
+        "q. end": [12, 16, 20, 30, 26, 22],
+    }
+)
 
 # Example DataFrame which matches biorisk hmmer outputs:
-example_hmmer_01_output = pd.DataFrame({
-    "query name": ["F1","F2","F3","R1","R2", "R3"],
-    "frame":    [1,2,3,4,5,6],
-    "ali from": [1, 2, 3, 1, 2, 3],
-    "ali to":   [4, 5, 6, 4, 5, 6],
-    "nt_qlen":  [31, 31, 31, 31, 31, 31],
-    "q. start": [ 1,  5,  9,  21,  17, 13],
-    "q. end":   [12, 16, 20,  32,  28, 24]
-})
+example_hmmer_01_output = pd.DataFrame(
+    {
+        "query name": ["F1", "F2", "F3", "R1", "R2", "R3"],
+        "frame": [1, 2, 3, 4, 5, 6],
+        "ali from": [1, 2, 3, 1, 2, 3],
+        "ali to": [4, 5, 6, 4, 5, 6],
+        "nt_qlen": [31, 31, 31, 31, 31, 31],
+        "q. start": [1, 5, 9, 21, 17, 13],
+        "q. end": [12, 16, 20, 32, 28, 24],
+    }
+)
+
 
 @pytest.mark.parametrize(
     "input_hmmer, expected_output_hmmer",
     [
         (example_hmmer_01, example_hmmer_01_output),
-    ]
+    ],
 )
-def test_hmmer_overlaps(
-    input_hmmer : pd.DataFrame,
-    expected_output_hmmer : pd.DataFrame
-):
+def test_hmmer_overlaps(input_hmmer: pd.DataFrame, expected_output_hmmer: pd.DataFrame):
     """
     Checks common configurations that require trimming in Hmmer outputs,
-    In particular partial overlaps, 
-    full encapsulations, score differences, 
+    In particular partial overlaps,
+    full encapsulations, score differences,
     and different queries.
     """
     print("INPUT:")
@@ -89,4 +94,4 @@ def test_hmmer_overlaps(
     print(expected_output_hmmer)
     print(expected_output_hmmer.dtypes)
     assert_frame_equal(input_hmmer, expected_output_hmmer)
-    #assert input_hmmer.equals(expected_output_hmmer)
+    # assert input_hmmer.equals(expected_output_hmmer)

--- a/commec/tests/test_blast_tools.py
+++ b/commec/tests/test_blast_tools.py
@@ -1,10 +1,17 @@
-from io import StringIO
-import pytest
 import textwrap
+from io import StringIO
 from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
-from commec.tools.blast_tools import _split_by_tax_id, read_blast, get_lineages, get_taxonomic_labels
+import pytest
+
+from commec.tools.blast_tools import (
+    _split_by_tax_id,
+    get_lineages,
+    get_taxonomic_labels,
+    read_blast,
+)
 
 
 @pytest.fixture
@@ -74,9 +81,7 @@ def test_split_by_tax_id(blast_df: pd.DataFrame):
 def test_get_lineages(mock_lineage, blast_df, lineage_df):
     mock_lineage.return_value = lineage_df
     blast_df = _split_by_tax_id(blast_df)
-    lin = get_lineages(
-        blast_df["subject tax ids"], "commec-dbs/taxonomy/", 8
-    )
+    lin = get_lineages(blast_df["subject tax ids"], "commec-dbs/taxonomy/", 8)
     # Expect the invalid taxid to be filtered out
     expected_tax_ids = {2371, 644357, 10760, 32630}
     assert set(lin["TaxID"]) == expected_tax_ids
@@ -86,8 +91,8 @@ def test_get_lineages(mock_lineage, blast_df, lineage_df):
 def test_taxdist(mock_lineage, blast_df, lineage_df):
     mock_lineage.return_value = lineage_df
     # Fake values - should find 1 regulated hit after filtering
-    reg_taxids = ['644357', '10760']
-    vax_taxids = ['10760']
+    reg_taxids = ["644357", "10760"]
+    vax_taxids = ["10760"]
     reg_df = get_taxonomic_labels(
         blast_df, reg_taxids, vax_taxids, "commec-dbs/taxonomy/", 8
     )

--- a/commec/tests/test_check_biorisk.py
+++ b/commec/tests/test_check_biorisk.py
@@ -1,20 +1,26 @@
-import pytest
-from unittest.mock import patch
-import pandas as pd
 import os
-from Bio.SeqRecord import SeqRecord, Seq
+from unittest.mock import patch
 
-from commec.screeners.check_biorisk import biorisk_evalue_filter, parse_biorisk_hits, HmmerHandler
-from commec.config.result import ScreenResult
-from commec.config.query import Query
+import pandas as pd
+import pytest
+from Bio.SeqRecord import Seq, SeqRecord
+
 from commec.config.constants import (
-    BIORISK_SHORT_QUERY_NT_THRESHOLD,
-    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
     BIORISK_LONG_QUERY_EVALUE_THRESHOLD,
+    BIORISK_SHORT_QUERY_EVALUE_EXPONENT,
+    BIORISK_SHORT_QUERY_NT_THRESHOLD,
+)
+from commec.config.query import Query
+from commec.config.result import ScreenResult
+from commec.screeners.check_biorisk import (
+    HmmerHandler,
+    biorisk_evalue_filter,
+    parse_biorisk_hits,
 )
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
+
 
 @pytest.mark.parametrize(
     "annotations_exists, has_empty_output, has_hits, expected_return",
@@ -29,7 +35,9 @@ DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
         (True, False, True, 0),
     ],
 )
-def test_check_biorisk_return_codes(annotations_exists, has_empty_output, has_hits, expected_return):
+def test_check_biorisk_return_codes(
+    annotations_exists, has_empty_output, has_hits, expected_return
+):
     mock_hit_df = pd.DataFrame(
         {
             "target name": ["test_id"],
@@ -38,7 +46,7 @@ def test_check_biorisk_return_codes(annotations_exists, has_empty_output, has_hi
             "ali from": [100],
             "ali to": [200],
             "qlen": [1000],
-            "frame" : 1
+            "frame": 1,
         }
     )
 
@@ -51,15 +59,33 @@ def test_check_biorisk_return_codes(annotations_exists, has_empty_output, has_hi
         patch("os.path.exists", return_value=annotations_exists),
         patch("pandas.read_csv", return_value=mock_annot_df),
         patch("commec.screeners.check_biorisk.readhmmer", return_value=mock_hit_df),
-        patch("commec.screeners.check_biorisk.remove_overlaps", return_value=mock_hit_df),
-        patch("commec.screeners.check_biorisk.HmmerHandler.has_empty_output", return_value=has_empty_output),
-        patch("commec.screeners.check_biorisk.HmmerHandler.has_hits", return_value=has_hits),
+        patch(
+            "commec.screeners.check_biorisk.remove_overlaps", return_value=mock_hit_df
+        ),
+        patch(
+            "commec.screeners.check_biorisk.HmmerHandler.has_empty_output",
+            return_value=has_empty_output,
+        ),
+        patch(
+            "commec.screeners.check_biorisk.HmmerHandler.has_hits",
+            return_value=has_hits,
+        ),
     ):
-        handler = HmmerHandler(DATABASE_DIRECTORY + "biorisk/biorisk.hmm", INPUT_QUERY, "/mock/path/test.hmmscan")
+        handler = HmmerHandler(
+            DATABASE_DIRECTORY + "biorisk/biorisk.hmm",
+            INPUT_QUERY,
+            "/mock/path/test.hmmscan",
+        )
         results = ScreenResult()
-        queries : dict[str,Query] = {"testname" : Query(SeqRecord(Seq("atgatgatgatgatgatgatg"),"testname","testname"))}
+        queries: dict[str, Query] = {
+            "testname": Query(
+                SeqRecord(Seq("atgatgatgatgatgatgatg"), "testname", "testname")
+            )
+        }
         # Run the function - input paths are unused given all the mocking above
-        result = parse_biorisk_hits(handler, "/mock/path/biorisk/biorisk_annotations.csv", results, queries)
+        result = parse_biorisk_hits(
+            handler, "/mock/path/biorisk/biorisk_annotations.csv", results, queries
+        )
 
         # Check the result
         assert result == expected_return
@@ -69,6 +95,7 @@ def test_check_biorisk_return_codes(annotations_exists, has_empty_output, has_hi
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_hmmer(nt_qlen: int, evalue: float) -> pd.DataFrame:
     """Return a minimal single-row hmmscan DataFrame."""
     return pd.DataFrame({"E-value": [evalue], "nt_qlen": [nt_qlen]})
@@ -76,12 +103,13 @@ def _make_hmmer(nt_qlen: int, evalue: float) -> pd.DataFrame:
 
 def _short_cutoff(nt_qlen: float) -> float:
     """Length-dependent E-value cutoff for short queries."""
-    return 1 / (1 + nt_qlen ** BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
+    return 1 / (1 + nt_qlen**BIORISK_SHORT_QUERY_EVALUE_EXPONENT)
 
 
 # ---------------------------------------------------------------------------
 # biorisk_evalue_filter — short-query regime (nt_qlen < threshold)
 # ---------------------------------------------------------------------------
+
 
 class TestBioriskEvalueFilterShortQuery:
     """nt_qlen below BIORISK_SHORT_QUERY_NT_THRESHOLD uses the power-law cutoff."""
@@ -116,6 +144,7 @@ class TestBioriskEvalueFilterShortQuery:
         result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
         assert len(result) == 1
 
+
 class TestBioriskEvalueFilterLongQuery:
     """nt_qlen at or above BIORISK_SHORT_QUERY_NT_THRESHOLD uses the fixed cutoff."""
 
@@ -131,21 +160,24 @@ class TestBioriskEvalueFilterLongQuery:
         result = biorisk_evalue_filter(_make_hmmer(nt_qlen, evalue))
         assert len(result) == 0
 
+
 class TestBioriskEvalueFilterMultiRow:
     """Tests covering mixed DataFrames and edge cases."""
 
     def test_mixed_rows_only_passing_rows_retained(self):
         nt_qlen_short = 100
         nt_qlen_long = 500
-        df = pd.DataFrame({
-            "E-value": [
-                _short_cutoff(nt_qlen_short) * 0.5,   # short, passes
-                _short_cutoff(nt_qlen_short) * 2.0,   # short, filtered
-                BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 0.1,  # long, passes
-                BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 10,   # long, filtered
-            ],
-            "nt_qlen": [nt_qlen_short, nt_qlen_short, nt_qlen_long, nt_qlen_long],
-        })
+        df = pd.DataFrame(
+            {
+                "E-value": [
+                    _short_cutoff(nt_qlen_short) * 0.5,  # short, passes
+                    _short_cutoff(nt_qlen_short) * 2.0,  # short, filtered
+                    BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 0.1,  # long, passes
+                    BIORISK_LONG_QUERY_EVALUE_THRESHOLD * 10,  # long, filtered
+                ],
+                "nt_qlen": [nt_qlen_short, nt_qlen_short, nt_qlen_long, nt_qlen_long],
+            }
+        )
         result = biorisk_evalue_filter(df)
         assert len(result) == 2
 
@@ -181,12 +213,14 @@ class TestBioriskEvalueFilterMultiRow:
         """Columns beyond E-value and nt_qlen must survive the filter unchanged."""
         nt_qlen = 100
         evalue = _short_cutoff(nt_qlen) * 0.5
-        df = pd.DataFrame({
-            "E-value": [evalue],
-            "nt_qlen": [nt_qlen],
-            "target name": ["some_target"],
-            "query name": ["some_query"],
-        })
+        df = pd.DataFrame(
+            {
+                "E-value": [evalue],
+                "nt_qlen": [nt_qlen],
+                "target name": ["some_target"],
+                "query name": ["some_query"],
+            }
+        )
         result = biorisk_evalue_filter(df)
         assert "target name" in result.columns
         assert result["target name"].iloc[0] == "some_target"

--- a/commec/tests/test_coverage.py
+++ b/commec/tests/test_coverage.py
@@ -9,8 +9,9 @@ The following behaviour is expected:
 
 import pandas as pd
 import pytest
-from commec.screeners.check_low_concern import _calculate_coverage
+
 from commec.config.result import MatchRange
+from commec.screeners.check_low_concern import _calculate_coverage
 
 # Test the following hmmer configuration:
 # 10-----------------50 (Largest, should stay.)
@@ -21,31 +22,36 @@ from commec.config.result import MatchRange
 # 10------------------------------90 (different query)
 
 # Example DataFrame
-example_hmmer_01 = pd.DataFrame({
-    "q. start": [100,  50,   0,   0],
-    "q. end":   [200, 150, 100, 200],
-})
+example_hmmer_01 = pd.DataFrame(
+    {
+        "q. start": [100, 50, 0, 0],
+        "q. end": [200, 150, 100, 200],
+    }
+)
 
 # Example DataFrame
-example_hmmer_01_output = pd.DataFrame({
-    "q. start":    [100,  50,   0,   0],
-    "q. end":      [200, 150, 100, 200],
-    "coverage_nt": [100,  50,   0, 100],
-    "coverage_ratio": [1.0, 0.5, 0.0, 1.0]
-})
+example_hmmer_01_output = pd.DataFrame(
+    {
+        "q. start": [100, 50, 0, 0],
+        "q. end": [200, 150, 100, 200],
+        "coverage_nt": [100, 50, 0, 100],
+        "coverage_ratio": [1.0, 0.5, 0.0, 1.0],
+    }
+)
 
 reg_range_01 = MatchRange(0.0, 100, 200, 100, 200)
+
 
 @pytest.mark.parametrize(
     "input_hmmer, input_region, expected_output_hmmer",
     [
         (example_hmmer_01, reg_range_01, example_hmmer_01_output),
-    ]
+    ],
 )
 def test_coverage_overlaps(
-    input_hmmer : pd.DataFrame,
-    input_region : MatchRange,
-    expected_output_hmmer : pd.DataFrame
+    input_hmmer: pd.DataFrame,
+    input_region: MatchRange,
+    expected_output_hmmer: pd.DataFrame,
 ):
     """
     Checks common configurations that require trimming in Hmmer outputs,

--- a/commec/tests/test_data/eval/.gitignore
+++ b/commec/tests/test_data/eval/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything in this folder by default...
+*
+
+# ...except these:
+!.gitignore
+!README.md
+!_template
+!_template/**

--- a/commec/tests/test_data/eval/README.md
+++ b/commec/tests/test_data/eval/README.md
@@ -1,0 +1,102 @@
+# Evaluation (detection) test cases
+
+This directory holds **end-to-end detection test cases** for `commec screen`, driven by
+`commec/tests/test_evaluation.py`. Unlike the mocked logic tests, these run the real
+pipeline against real reference databases and check that known sequences produce the
+expected screening outcome.
+
+## How it works
+
+Each **subfolder** of this directory is one test case. A subfolder is collected as a case
+when it contains a `metadata.yaml` (or `metadata.yml`) file. The harness:
+
+1. discovers every case subfolder (folders starting with `_` or `.` are ignored — use
+   them for templates/notes, like `_template/`);
+2. runs `commec screen` on the case's FASTA against the database directory you provide;
+3. compares the resulting per-query statuses (and optional hit/rationale checks) against
+   the `expected` block in `metadata.yaml`.
+
+Because the reference databases are large and not in the repo, these tests are **skipped**
+unless you point them at a database directory:
+
+```bash
+pytest commec/tests/test_evaluation.py --commec-db-dir /path/to/commec-dbs
+# or:
+COMMEC_DB_DIR=/path/to/commec-dbs pytest commec/tests/test_evaluation.py
+```
+
+## Layout of a case
+
+```
+eval/
+  my_case_name/
+    metadata.yaml          # required — describes the case and expected outcomes
+    sequence.fasta         # the input to screen
+```
+
+By default a case has exactly one FASTA file and that file holds a single record. A FASTA
+may hold multiple records (e.g. to test "distribution attacks" that split a sequence of
+concern across records); just add an `expected` entry per record id.
+
+## `metadata.yaml` schema
+
+```yaml
+# Human-readable description (optional, recommended).
+name: dataset_name
+description: >
+  Dataset Description
+
+# Which FASTA to screen (optional). If omitted, the single *.fasta in the folder is used.
+fasta: sequence.fasta
+
+# Extra CLI args passed verbatim to `commec screen` (optional). e.g. ["--skip-nt"].
+screen_args: []
+
+# Expected outcomes (required).
+#
+# Two forms are accepted:
+#
+# (A) Single-query shorthand — write the status fields directly. Only valid when the
+#     FASTA produces exactly one query:
+expected:
+  screen_status: Flag          # overall outcome (required)
+  biorisk: Flag                # per-step expectations (all optional)
+  protein_taxonomy: Flag
+  nucleotide_taxonomy: Pass
+  low_concern: Pass
+  hits: []                     # optional: hit names that MUST be present for the query
+  rationale_contains: []       # optional: substrings that MUST appear in the rationale
+
+# (B) Per-query form — key by FASTA record id (the header up to the first space).
+#     Use this for multi-record FASTAs:
+#
+# expected:
+#   record_id_1:
+#     screen_status: Flag
+#     biorisk: Flag
+#   record_id_2:
+#     screen_status: Pass
+```
+
+### Status values
+
+Status fields accept either the human-readable enum value or the enum name (case
+sensitive for the value, case-insensitive for the name):
+
+| Name           | Value               |
+|----------------|---------------------|
+| `NULL`         | `-`                 |
+| `SKIP`         | `Skip`              |
+| `SKIP_SHORT`   | `Skip (too short)`  |
+| `SKIP_LONG`    | `Skip (too long)`   |
+| `PASS`         | `Pass`              |
+| `CLEARED_WARN` | `Warning (Cleared)` |
+| `CLEARED_FLAG` | `Flag (Cleared)`    |
+| `WARN`         | `Warning`           |
+| `FLAG`         | `Flag`              |
+| `STOP`         | `Incomplete`        |
+| `ERROR`        | `Error`             |
+
+So `screen_status: Flag` and `screen_status: FLAG` are equivalent.
+
+Only the fields you specify are checked — omit a step's field to leave it unasserted.

--- a/commec/tests/test_data/eval/_template/metadata.yaml
+++ b/commec/tests/test_data/eval/_template/metadata.yaml
@@ -1,0 +1,37 @@
+# Template evaluation case. Copy this folder to a new name (without the leading
+# underscore) and drop in a real FASTA to create a detection test.
+#
+# Folders starting with "_" are ignored by the test harness, so this template is never
+# collected as a test. See ../README.md for the full schema.
+
+name: template_case
+description: >
+  One-line description of what this dataset is and why it should screen the way it does.
+
+# Optional: which FASTA in this folder to screen. Omit if there is exactly one.
+fasta: sequence.fasta
+
+# Optional: extra CLI flags passed straight to `commec screen`.
+screen_args: []
+
+# Required: the expected screening outcome.
+#
+# Single-query shorthand (use when the FASTA has one record). Only `screen_status` is
+# required; the per-step fields, `hits`, and `rationale_contains` are all optional.
+expected:
+  screen_status: Flag
+  biorisk: Flag
+  protein_taxonomy: Pass
+  nucleotide_taxonomy: Pass
+  low_concern: Pass
+  # hits: ["expected_hit_name"]
+  # rationale_contains: ["pathogenic or toxin function"]
+
+# Per-query form (use for multi-record FASTAs); key by FASTA record id:
+#
+# expected:
+#   record_one:
+#     screen_status: Flag
+#     biorisk: Flag
+#   record_two:
+#     screen_status: Pass

--- a/commec/tests/test_dbs.py
+++ b/commec/tests/test_dbs.py
@@ -1,14 +1,17 @@
-""" 
+"""
 Unit test for ensuring that the databases are being called without errors.
 Will fail if databases have not been installed as expected, with correct versions.
 """
+
 import os
+
 import pytest
-from commec.tools.diamond import DiamondHandler
+
 from commec.tools.blastn import BlastNHandler
 from commec.tools.blastx import BlastXHandler
-from commec.tools.hmmer import HmmerHandler
 from commec.tools.cmscan import CmscanHandler
+from commec.tools.diamond import DiamondHandler
+from commec.tools.hmmer import HmmerHandler
 from commec.tools.search_handler import DatabaseValidationError
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
@@ -22,10 +25,12 @@ databases_to_implement = [
     [CmscanHandler, "low_concern/rna", "benign.cm"],
 ]
 
+
 def print_tmp_path_contents(tmp_path):
     print(f"Contents of {tmp_path}:")
     for path in tmp_path.rglob("*"):  # Recursively list all files and directories
         print(path.relative_to(tmp_path), "->", "DIR" if path.is_dir() else "FILE")
+
 
 @pytest.mark.parametrize("input_db", databases_to_implement)
 def test_database_can_run(input_db):
@@ -88,9 +93,9 @@ def test_database_no_file(input_db):
     except DatabaseValidationError:
         assert True
 
-n_jobs = [
-    None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-]
+
+n_jobs = [None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
 
 @pytest.mark.parametrize("input_jobs", n_jobs)
 def test_diamond_job_and_threads_calculations(input_jobs):
@@ -122,8 +127,9 @@ def test_diamond_job_and_threads_calculations(input_jobs):
             # We should ALWAYS use all available threads.
             # We may use less than Max Threads if the remainder is 0 for the no. of database files
             if input_jobs is None:
-                assert ((concurrent_runs * threads_per_run == max_threads) or
-                        (concurrent_runs * threads_per_run % n_database_files == 0)), f"""
+                assert (concurrent_runs * threads_per_run == max_threads) or (
+                    concurrent_runs * threads_per_run % n_database_files == 0
+                ), f"""
                 {concurrent_runs} runs with {threads_per_run} threads. Input settings:
                 {max_threads} max threads, {n_database_files} dbs, {input_jobs} input jobs no.
                 """
@@ -132,13 +138,13 @@ def test_diamond_job_and_threads_calculations(input_jobs):
 @pytest.mark.parametrize(
     "input_jobs, max_threads, n_database_files, expected_runs, expected_threads",
     [
-        (None, 20, 6, 2, 10), # jobs capped by db count, using all threads
-        (None, 8, 5, 1, 5),   # jobs capped by db count, not using all threads
-        (3, 12, 6, 3, 4),     # jobs=3 --> 3 runs with 4 threads each
-        (10, 20, 5, 5, 4),    # jobs=10 > db=5, capped to 5 runs with 4 threads each
-        (20, 10, 5, 5, 2),    # jobs=20 > threads=10, capped to 5 runs with 2 threads each
-        (10, 4, 5, 4, 1),     # jobs=10 > db, threads, cappted to 4 runs with 1 thread each
-    ]
+        (None, 20, 6, 2, 10),  # jobs capped by db count, using all threads
+        (None, 8, 5, 1, 5),  # jobs capped by db count, not using all threads
+        (3, 12, 6, 3, 4),  # jobs=3 --> 3 runs with 4 threads each
+        (10, 20, 5, 5, 4),  # jobs=10 > db=5, capped to 5 runs with 4 threads each
+        (20, 10, 5, 5, 2),  # jobs=20 > threads=10, capped to 5 runs with 2 threads each
+        (10, 4, 5, 4, 1),  # jobs=10 > db, threads, cappted to 4 runs with 1 thread each
+    ],
 )
 def test_diamond_job_and_threads_calculations_parametrized(
     input_jobs, max_threads, n_database_files, expected_runs, expected_threads
@@ -153,8 +159,8 @@ def test_diamond_job_and_threads_calculations_parametrized(
     )
     handler.jobs = input_jobs
     concurrent_runs, threads_per_run = handler.determine_runs_and_threads(
-                max_threads, n_database_files
-            )
+        max_threads, n_database_files
+    )
 
     assert concurrent_runs == expected_runs, f"""
         {input_jobs} jobs, {max_threads} threads failed

--- a/commec/tests/test_evaluation.py
+++ b/commec/tests/test_evaluation.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021-2024 International Biosecurity and Biosafety Initiative for Science
+"""
+Data-driven, end-to-end detection ("evaluation") tests for ``commec screen``.
+
+Unlike the mocked logic tests (see ``screen_factory.py``), these tests run the *real*
+screening pipeline against *real* reference databases and assert on the detection outcome
+for known sequences. Each test case is a subfolder of ``test_data/eval/`` containing:
+
+  * a ``metadata.yaml`` (or ``.yml``) file describing the case and its expected outcomes;
+  * one FASTA file of input sequence(s) to screen.
+
+A FASTA is expected to hold a single record by default, but may hold several (for example
+to test "distribution attacks" that split a sequence of concern across multiple records);
+expected outcomes are keyed by FASTA record id, so multi-record cases are supported.
+
+See ``test_data/eval/README.md`` for the full ``metadata.yaml`` schema.
+
+Because the real reference databases are not stored in the repository, these tests are
+SKIPPED unless a database directory is supplied, either via::
+
+    pytest --commec-db-dir /path/to/commec-dbs
+
+or by setting the ``COMMEC_DB_DIR`` environment variable.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from commec.screen import ScreenArgumentParser, add_args, run
+from commec.config.json_io import get_screen_data_from_json
+from commec.config.result import ScreenResult, ScreenStatus, QueryResult
+
+# Root directory under which each subfolder is one evaluation case.
+EVAL_DIR = Path(__file__).parent / "test_data" / "eval"
+
+# Accepted names for a case's metadata file, in order of preference.
+METADATA_FILENAMES = ("metadata.yaml", "metadata.yml")
+
+# Per-step status fields on QueryScreenStatus that a case may assert against.
+# "screen_status" is the overall outcome and is the only required expectation.
+STATUS_FIELDS = (
+    "screen_status",
+    "biorisk",
+    "protein_taxonomy",
+    "nucleotide_taxonomy",
+    "low_concern",
+)
+
+
+# --------------------------------------------------------------------------------------
+# Case discovery
+# --------------------------------------------------------------------------------------
+def _discover_cases() -> list[Path]:
+    """
+    Return the sorted list of evaluation case directories under ``EVAL_DIR``.
+
+    A directory is a case if it contains a metadata file. Folders whose name starts with
+    ``_`` or ``.`` are ignored, so e.g. ``_template/`` can hold documentation/examples
+    without being collected as a test.
+    """
+    if not EVAL_DIR.is_dir():
+        return []
+
+    cases = []
+    for entry in sorted(EVAL_DIR.iterdir()):
+        if not entry.is_dir() or entry.name.startswith(("_", ".")):
+            continue
+        if any((entry / name).is_file() for name in METADATA_FILENAMES):
+            cases.append(entry)
+    return cases
+
+
+def _case_id(case_dir: Path) -> str:
+    return case_dir.name
+
+
+_CASES = _discover_cases()
+
+if _CASES:
+    _CASE_PARAMS = [pytest.param(c, id=_case_id(c)) for c in _CASES]
+else:
+    # Keep a single, clearly-labelled skipped test rather than collecting nothing, so
+    # that an empty/absent eval directory is visible in the test report.
+    _CASE_PARAMS = [
+        pytest.param(
+            None,
+            id="no-eval-cases",
+            marks=pytest.mark.skip(
+                reason=f"No evaluation cases found in {EVAL_DIR}"
+            ),
+        )
+    ]
+
+
+# --------------------------------------------------------------------------------------
+# Fixtures and helpers
+# --------------------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def eval_database_dir(request) -> Path:
+    """
+    Resolve the real commec database directory from ``--commec-db-dir`` or the
+    ``COMMEC_DB_DIR`` env var. Skips the test when neither is set or the path is invalid.
+    """
+    raw = request.config.getoption("--commec-db-dir") or os.environ.get("COMMEC_DB_DIR")
+    if not raw:
+        pytest.skip(
+            "No commec database directory provided; pass --commec-db-dir or set"
+            " COMMEC_DB_DIR to run the end-to-end detection tests."
+        )
+    db_dir = Path(raw).expanduser()
+    if not db_dir.is_dir():
+        pytest.skip(f"commec database directory does not exist: {db_dir}")
+    return db_dir
+
+
+def _load_metadata(case_dir: Path) -> dict:
+    """Load and minimally validate the metadata for a case directory."""
+    meta_path = next(
+        (case_dir / name for name in METADATA_FILENAMES if (case_dir / name).is_file()),
+        None,
+    )
+    assert meta_path is not None, f"No metadata file found in {case_dir}"
+
+    with open(meta_path, encoding="utf-8") as handle:
+        metadata = yaml.safe_load(handle) or {}
+
+    assert isinstance(metadata, dict), f"{meta_path} must contain a YAML mapping"
+    assert "expected" in metadata, f"{meta_path} is missing the required 'expected' key"
+    return metadata
+
+
+def _resolve_fasta(case_dir: Path, metadata: dict) -> Path:
+    """
+    Determine which FASTA in the case directory to screen.
+
+    Uses ``metadata['fasta']`` if given; otherwise requires exactly one ``*.fasta`` /
+    ``*.fa`` file in the directory.
+    """
+    named = metadata.get("fasta")
+    if named:
+        fasta = case_dir / named
+        assert fasta.is_file(), f"FASTA named in metadata not found: {fasta}"
+        return fasta
+
+    candidates = sorted(
+        p for p in case_dir.iterdir() if p.suffix.lower() in (".fasta", ".fa")
+    )
+    assert candidates, f"No FASTA file found in {case_dir}"
+    assert len(candidates) == 1, (
+        f"Multiple FASTA files in {case_dir}; name one explicitly with the 'fasta' key"
+        f" in metadata. Found: {[p.name for p in candidates]}"
+    )
+    return candidates[0]
+
+
+def _parse_status(value) -> ScreenStatus:
+    """
+    Coerce a metadata status value into a ``ScreenStatus``.
+
+    Accepts either the enum *value* (the human string, e.g. ``"Flag"``,
+    ``"Flag (Cleared)"``) or the enum *name* (e.g. ``"FLAG"``, ``"CLEARED_FLAG"``).
+    """
+    if isinstance(value, ScreenStatus):
+        return value
+    text = str(value)
+    try:
+        return ScreenStatus(text)
+    except ValueError:
+        pass
+    try:
+        return ScreenStatus[text.upper()]
+    except KeyError as exc:
+        valid = ", ".join(f"{s.name}={s.value!r}" for s in ScreenStatus)
+        raise AssertionError(
+            f"Unknown ScreenStatus {value!r} in metadata. Valid options: {valid}"
+        ) from exc
+
+
+def _normalise_expectations(expected) -> dict[str, dict]:
+    """
+    Normalise the ``expected`` block into ``{query_id: {field: expectation, ...}}``.
+
+    Supports a single-query shorthand where the status fields are written directly under
+    ``expected`` (with no query-id nesting); these are applied to the sole query under the
+    sentinel key ``None``.
+    """
+    assert isinstance(expected, dict), "'expected' must be a mapping"
+
+    # Shorthand: status fields written directly (single, unnamed query).
+    if set(expected).issubset(set(STATUS_FIELDS) | {"hits", "rationale_contains"}):
+        return {None: expected}
+
+    # Otherwise, keys are query ids mapping to their own expectation blocks.
+    out = {}
+    for query_id, fields in expected.items():
+        assert isinstance(fields, dict), (
+            f"Expectation for query {query_id!r} must be a mapping of fields"
+        )
+        out[str(query_id)] = fields
+    return out
+
+
+def _find_query(result: ScreenResult, query_id) -> QueryResult:
+    """
+    Locate the QueryResult for an expected query id, tolerant of how commec keys queries.
+
+    ``query_id`` may be ``None`` (the single-query shorthand), the internal query name
+    (the ``queries`` dict key), or the original FASTA record id.
+    """
+    queries = result.queries
+    if query_id is None:
+        assert len(queries) == 1, (
+            "Single-query shorthand used, but the screen produced"
+            f" {len(queries)} queries: {list(queries)}. Key 'expected' by query id."
+        )
+        return next(iter(queries.values()))
+
+    if query_id in queries:
+        return queries[query_id]
+
+    for query in queries.values():
+        if query.query == query_id:
+            return query
+
+    resolved = result.get_query(query_id)
+    assert resolved is not None, (
+        f"Expected query {query_id!r} not found in screen output."
+        f" Queries present: {list(queries)}"
+    )
+    return resolved
+
+
+def _run_screen(fasta: Path, db_dir: Path, output_dir: Path, screen_args: list[str]) -> ScreenResult:
+    """Run a real ``commec screen`` and return the parsed ScreenResult."""
+    arguments = [
+        "commec-screen",
+        str(fasta),
+        "-d", str(db_dir),
+        "-o", str(output_dir),
+        "-F",  # force a fresh run into the (empty) tmp output dir
+    ]
+    arguments.extend(screen_args)
+
+    with patch("sys.argv", arguments):
+        parser = ScreenArgumentParser()
+        add_args(parser)
+        args = parser.parse_args()
+        run(args)
+
+    # When -o is a directory, the output JSON is named after the input FASTA.
+    output_json = output_dir / f"{fasta.stem}.output.json"
+    if not output_json.is_file():
+        # Fall back to any *.output.json produced, to be robust to naming changes.
+        produced = sorted(output_dir.glob("*.output.json"))
+        assert produced, f"No screen JSON output produced in {output_dir}"
+        output_json = produced[0]
+
+    return get_screen_data_from_json(str(output_json))
+
+
+# --------------------------------------------------------------------------------------
+# The test
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("case_dir", _CASE_PARAMS)
+def test_evaluation_case(case_dir: Path, eval_database_dir: Path, tmp_path: Path):
+    """
+    Run ``commec screen`` on a single evaluation case and assert its expected outcomes.
+    """
+    metadata = _load_metadata(case_dir)
+    fasta = _resolve_fasta(case_dir, metadata)
+    screen_args = [str(a) for a in metadata.get("screen_args", [])]
+
+    result = _run_screen(fasta, eval_database_dir, tmp_path, screen_args)
+
+    expectations = _normalise_expectations(metadata["expected"])
+    case_name = case_dir.name
+
+    failures: list[str] = []
+    for query_id, fields in expectations.items():
+        query = _find_query(result, query_id)
+        label = query.query or query_id or "<single query>"
+
+        for field in STATUS_FIELDS:
+            if field not in fields:
+                continue
+            expected_status = _parse_status(fields[field])
+            actual_status = getattr(query.status, field)
+            if actual_status != expected_status:
+                failures.append(
+                    f"[{case_name}:{label}] {field}: expected {expected_status.value!r},"
+                    f" got {actual_status.value!r}"
+                )
+
+        # Optional: assert that named hits were detected for this query.
+        for hit_name in fields.get("hits", []):
+            if hit_name not in query.hits:
+                failures.append(
+                    f"[{case_name}:{label}] expected hit {hit_name!r} not found."
+                    f" Hits present: {list(query.hits)}"
+                )
+
+        # Optional: assert substrings appear in the rationale text.
+        for fragment in fields.get("rationale_contains", []):
+            if fragment not in query.status.rationale:
+                failures.append(
+                    f"[{case_name}:{label}] rationale missing {fragment!r}."
+                    f" Rationale: {query.status.rationale!r}"
+                )
+
+    assert not failures, "Evaluation case mismatch:\n" + "\n".join(failures)

--- a/commec/tests/test_evaluation.py
+++ b/commec/tests/test_evaluation.py
@@ -31,9 +31,9 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from commec.screen import ScreenArgumentParser, add_args, run
 from commec.config.json_io import get_screen_data_from_json
-from commec.config.result import ScreenResult, ScreenStatus, QueryResult
+from commec.config.result import QueryResult, ScreenResult, ScreenStatus
+from commec.screen import ScreenArgumentParser, add_args, run
 
 # Root directory under which each subfolder is one evaluation case.
 EVAL_DIR = Path(__file__).parent / "test_data" / "eval"
@@ -90,9 +90,7 @@ else:
         pytest.param(
             None,
             id="no-eval-cases",
-            marks=pytest.mark.skip(
-                reason=f"No evaluation cases found in {EVAL_DIR}"
-            ),
+            marks=pytest.mark.skip(reason=f"No evaluation cases found in {EVAL_DIR}"),
         )
     ]
 
@@ -235,13 +233,17 @@ def _find_query(result: ScreenResult, query_id) -> QueryResult:
     return resolved
 
 
-def _run_screen(fasta: Path, db_dir: Path, output_dir: Path, screen_args: list[str]) -> ScreenResult:
+def _run_screen(
+    fasta: Path, db_dir: Path, output_dir: Path, screen_args: list[str]
+) -> ScreenResult:
     """Run a real ``commec screen`` and return the parsed ScreenResult."""
     arguments = [
         "commec-screen",
         str(fasta),
-        "-d", str(db_dir),
-        "-o", str(output_dir),
+        "-d",
+        str(db_dir),
+        "-o",
+        str(output_dir),
         "-F",  # force a fresh run into the (empty) tmp output dir
     ]
     arguments.extend(screen_args)

--- a/commec/tests/test_fetch_nc_bits.py
+++ b/commec/tests/test_fetch_nc_bits.py
@@ -1,9 +1,7 @@
-from io import StringIO
 import os
 import pandas as pd
 import pytest
 import textwrap
-from Bio import SeqIO
 from unittest.mock import patch
 
 from commec.tools.fetch_nc_bits import (

--- a/commec/tests/test_fetch_nc_bits.py
+++ b/commec/tests/test_fetch_nc_bits.py
@@ -1,20 +1,21 @@
 import os
-import pandas as pd
-import pytest
 import textwrap
 from unittest.mock import patch
 
+import pandas as pd
+import pytest
+
+from commec.config.result import QueryResult, ScreenStatus
+from commec.config.screen_io import ScreenIO
+from commec.screen import ScreenArgumentParser, add_args
+from commec.tools.blastx import BlastXHandler
 from commec.tools.fetch_nc_bits import (
     _get_ranges_with_no_hits,
     calculate_noncoding_regions_per_query,
 )
 
-from commec.config.screen_io import ScreenIO
-from commec.config.result import QueryResult, ScreenStatus
-from commec.screen import add_args, ScreenArgumentParser
-from commec.tools.blastx import BlastXHandler
-
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs")
+
 
 @pytest.mark.parametrize(
     "hits, query_length, nc_ranges",
@@ -118,7 +119,15 @@ def test_fetch_nocoding_regions(tmp_path):
     # Create Dictionary of queries for funciton input.
     with patch(
         "sys.argv",
-        ["test.py", "--skip-tx", str(input_fasta), "-d", str(DATABASE_DIRECTORY), "-o", str(tmp_path)],
+        [
+            "test.py",
+            "--skip-tx",
+            str(input_fasta),
+            "-d",
+            str(DATABASE_DIRECTORY),
+            "-o",
+            str(tmp_path),
+        ],
     ):
         parser = ScreenArgumentParser()
         add_args(parser)

--- a/commec/tests/test_flag.py
+++ b/commec/tests/test_flag.py
@@ -1,10 +1,11 @@
-import os
 import argparse
+import os
 import textwrap
 
 from commec.flag import add_args, run
 
 SCREEN_DIR = os.path.join(os.path.dirname(__file__), "test_data")
+
 
 def test_flag(tmp_path):
     """We are lazily writing tests for a full run of flag instead of unit tests."""
@@ -57,4 +58,4 @@ def test_evalportal_format(tmp_path):
         """
     )
     actual_status = status_output.read_text()
-    assert expected_status.strip() == actual_status.strip()    
+    assert expected_status.strip() == actual_status.strip()

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -6,7 +6,6 @@ import yaml
 from commec.config.screen_io import ScreenIO
 from commec.cli import ScreenArgumentParser
 from commec.screen import add_args
-from commec.utils.file_utils import expand_and_normalize
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -1,44 +1,42 @@
-import pytest
-from unittest.mock import patch
 import os
+from unittest.mock import patch
+
+import pytest
 import yaml
 
-from commec.config.screen_io import ScreenIO
 from commec.cli import ScreenArgumentParser
+from commec.config.screen_io import ScreenIO
 from commec.screen import add_args
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
 
+
 @pytest.fixture
 def expected_defaults():
     return {
-        "base_paths": {
-            "default": "commec-dbs/"
-        },
+        "base_paths": {"default": "commec-dbs/"},
         "databases": {
             "low_concern": {
                 "rna": {"path": "commec-dbs/low_concern/rna/low_concern.cm"},
                 "dna": {"path": "commec-dbs/low_concern/dna/low_concern.fasta"},
                 "protein": {"path": "commec-dbs/low_concern/protein/low_concern.hmm"},
-                "annotations": 'commec-dbs/low_concern/low_concern_annotations.tsv',
-                "taxids": "commec-dbs/low_concern/vax_taxids.txt"
+                "annotations": "commec-dbs/low_concern/low_concern_annotations.tsv",
+                "taxids": "commec-dbs/low_concern/vax_taxids.txt",
             },
             "biorisk": {
                 "path": "commec-dbs/biorisk/biorisk.hmm",
-                "annotations": 'commec-dbs/biorisk/biorisk_annotations.csv',
+                "annotations": "commec-dbs/biorisk/biorisk_annotations.csv",
                 "taxids": "commec-dbs/biorisk/reg_taxids.txt",
             },
-            "regulated_nt": {
-                "path": "commec-dbs/nt_blast/core_nt"
-            },
+            "regulated_nt": {"path": "commec-dbs/nt_blast/core_nt"},
             "regulated_protein": {
                 "blast": {"path": "commec-dbs/nr_blast/nr"},
-                "diamond": {"path": "commec-dbs/nr_dmnd/nr.dmnd"}
+                "diamond": {"path": "commec-dbs/nr_dmnd/nr.dmnd"},
             },
             "taxonomy": {
                 "path": "commec-dbs/taxonomy/",
-            }
+            },
         },
         "threads": 1,
         "protein_search_tool": "blastx",
@@ -48,51 +46,45 @@ def expected_defaults():
         "diamond_jobs": None,
         "force": False,
         "resume": False,
-        "verbose": False
+        "verbose": False,
     }
+
 
 @pytest.fixture
 def custom_yaml_config():
     return {
-        "databases": {
-            "biorisk": {
-                "taxids" : "custom_path.txt"
-            }
-        },
+        "databases": {"biorisk": {"taxids": "custom_path.txt"}},
         "skip_taxonomy_search": True,
         "force": True,
         "threads": 8,
     }
 
+
 @pytest.fixture
 def expected_updated_from_custom_yaml():
     return {
-        "base_paths": {
-            "default": "commec-dbs/"
-        },
+        "base_paths": {"default": "commec-dbs/"},
         "databases": {
             "low_concern": {
                 "rna": {"path": "commec-dbs/low_concern/rna/low_concern.cm"},
                 "dna": {"path": "commec-dbs/low_concern/dna/low_concern.fasta"},
                 "protein": {"path": "commec-dbs/low_concern/protein/low_concern.hmm"},
-                "annotations": 'commec-dbs/low_concern/low_concern_annotations.tsv',
-                "taxids": "commec-dbs/low_concern/vax_taxids.txt"
+                "annotations": "commec-dbs/low_concern/low_concern_annotations.tsv",
+                "taxids": "commec-dbs/low_concern/vax_taxids.txt",
             },
             "biorisk": {
                 "path": "commec-dbs/biorisk/biorisk.hmm",
-                "annotations": 'commec-dbs/biorisk/biorisk_annotations.csv',
+                "annotations": "commec-dbs/biorisk/biorisk_annotations.csv",
                 "taxids": "custom_path.txt",
             },
-            "regulated_nt": {
-                "path": "commec-dbs/nt_blast/core_nt"
-            },
+            "regulated_nt": {"path": "commec-dbs/nt_blast/core_nt"},
             "regulated_protein": {
                 "blast": {"path": "commec-dbs/nr_blast/nr"},
-                "diamond": {"path": "commec-dbs/nr_dmnd/nr.dmnd"}
+                "diamond": {"path": "commec-dbs/nr_dmnd/nr.dmnd"},
             },
             "taxonomy": {
                 "path": "commec-dbs/taxonomy/",
-            }
+            },
         },
         "threads": 8,
         "protein_search_tool": "blastx",
@@ -102,44 +94,50 @@ def expected_updated_from_custom_yaml():
         "diamond_jobs": None,
         "force": True,
         "resume": False,
-        "verbose": False
+        "verbose": False,
     }
+
 
 def test_missing_input_file():
     args = ScreenArgumentParser()
     add_args(args)
     with pytest.raises(SystemExit):
         args = args.parse_args()
-    
+
+
 def test_default_config_only(expected_defaults):
     """Test that default config is loaded when no overrides exist"""
     parser = ScreenArgumentParser()
     add_args(parser)
     args = parser.parse_args([INPUT_QUERY])
     params = ScreenIO(args)
-    
+
     assert expected_defaults == params.config
 
-def test_user_yaml_override(tmp_path, expected_updated_from_custom_yaml, custom_yaml_config):
+
+def test_user_yaml_override(
+    tmp_path, expected_updated_from_custom_yaml, custom_yaml_config
+):
     """Test that user YAML properly overrides default config"""
     # Create user config
     user_config_path = tmp_path / "user_config.yaml"
-    with open(user_config_path, 'w') as f:
+    with open(user_config_path, "w") as f:
         yaml.dump(custom_yaml_config, f)
-    
+
     parser = ScreenArgumentParser()
     add_args(parser)
     args = parser.parse_args([INPUT_QUERY, "--config", str(user_config_path)])
     params = ScreenIO(args)
-    
+
     # Check that user YAML values override defaults
     assert expected_updated_from_custom_yaml == params.config
+
 
 def test_cli_override(tmp_path, expected_updated_from_custom_yaml, custom_yaml_config):
     """Test that CLI args properly override both YAML configs"""
     # Create user config
     user_config_path = tmp_path / "user_config.yaml"
-    with open(user_config_path, 'w') as f:
+    with open(user_config_path, "w") as f:
         yaml.dump(custom_yaml_config, f)
 
     # Add CLI args
@@ -147,18 +145,18 @@ def test_cli_override(tmp_path, expected_updated_from_custom_yaml, custom_yaml_c
         INPUT_QUERY,
         "--config",
         str(user_config_path),
-        "--skip-tx", # skip taxonomy
-        "--skip-nt", # skip nt search
-        "-c", # do_cleanup
+        "--skip-tx",  # skip taxonomy
+        "--skip-nt",  # skip nt search
+        "-c",  # do_cleanup
         "-d",
-        str(tmp_path)
+        str(tmp_path),
     ]
 
     parser = ScreenArgumentParser()
     add_args(parser)
     args = parser.parse_args(cli_args)
     params = ScreenIO(args)
-    
+
     # Override defaults with user YAML
     expected_updated_from_custom_yaml["skip_nt_search"] = True
     expected_updated_from_custom_yaml["do_cleanup"] = True
@@ -169,17 +167,20 @@ def test_cli_override(tmp_path, expected_updated_from_custom_yaml, custom_yaml_c
         Recursively apply string formatting to read paths from nested yaml config dicts.
         """
         if isinstance(dictionary, dict):
-            return {key : recursive_override(value, str_to_override, override_str) 
-                    for key, value in dictionary.items()}
+            return {
+                key: recursive_override(value, str_to_override, override_str)
+                for key, value in dictionary.items()
+            }
         if isinstance(dictionary, str):
-           return dictionary.replace(str_to_override, override_str)
+            return dictionary.replace(str_to_override, override_str)
         return dictionary
-    
+
     expected_defaults = recursive_override(
         expected_updated_from_custom_yaml, db_str_to_override, str(tmp_path) + "/"
     )
 
     assert expected_defaults == params.config
+
 
 def test_missing_default_config():
     """Test that missing default config raises appropriate error"""
@@ -188,47 +189,54 @@ def test_missing_default_config():
         args = ScreenArgumentParser()
         add_args(args)
         args = args.parse_args([INPUT_QUERY])
-        
+
         with pytest.raises(FileNotFoundError, match="No default yaml found"):
             _ = ScreenIO(args)
-
 
 
 @pytest.mark.parametrize(
     "base_path, low_concern_path, expected_path",
     [
         # Expected (basepath has terminal separator)
-        ("commec-test/", "{default}low_concern/rna/test.cm", "commec-test/low_concern/rna/test.cm"),
+        (
+            "commec-test/",
+            "{default}low_concern/rna/test.cm",
+            "commec-test/low_concern/rna/test.cm",
+        ),
         # No separators
-        ("commec-test", "{default}low_concern/rna/test.cm", "commec-test/low_concern/rna/test.cm"),
+        (
+            "commec-test",
+            "{default}low_concern/rna/test.cm",
+            "commec-test/low_concern/rna/test.cm",
+        ),
         # Subpath has separator
-        ("commec-test", "{default}/low_concern/rna/test.cm", "commec-test//low_concern/rna/test.cm"),
+        (
+            "commec-test",
+            "{default}/low_concern/rna/test.cm",
+            "commec-test//low_concern/rna/test.cm",
+        ),
         # Double separators
-        ("commec-test/", "{default}/low_concern/rna/test.cm", "commec-test//low_concern/rna/test.cm"),
+        (
+            "commec-test/",
+            "{default}/low_concern/rna/test.cm",
+            "commec-test//low_concern/rna/test.cm",
+        ),
     ],
 )
 def test_format_config_paths(tmp_path, base_path, low_concern_path, expected_path):
     config_yaml = {
-        "base_paths": {
-            "default": base_path
-        },
-        "databases": {
-            "low_concern" : {
-                "rna" : {
-                    "path": low_concern_path
-                }
-            }
-        }
+        "base_paths": {"default": base_path},
+        "databases": {"low_concern": {"rna": {"path": low_concern_path}}},
     }
     user_config_path = tmp_path / "user_config.yaml"
-    with open(user_config_path, 'w') as f:
+    with open(user_config_path, "w") as f:
         yaml.dump(config_yaml, f)
-    
+
     parser = ScreenArgumentParser()
     add_args(parser)
     args = parser.parse_args([INPUT_QUERY, "--config", str(user_config_path)])
     params = ScreenIO(args)
-    
+
     assert expected_path == params.config["databases"]["low_concern"]["rna"]["path"]
 
 
@@ -251,11 +259,13 @@ def test_format_config_paths(tmp_path, base_path, low_concern_path, expected_pat
 def test_get_output_prefix(
     mock_makedirs, input_file, prefix_arg, expected_prefix, is_makedirs_called
 ):
-    prefix, output_prefix, input_prefix = ScreenIO._get_output_prefixes(input_file, prefix_arg)
+    prefix, output_prefix, input_prefix = ScreenIO._get_output_prefixes(
+        input_file, prefix_arg
+    )
     assert expected_prefix == prefix, f"Expected: {expected_prefix}, got {prefix}"
 
     # Verify makedirs was called when appropriate
-    #if is_makedirs_called:
+    # if is_makedirs_called:
     #    mock_makedirs.assert_called_once_with(expand_and_normalize(prefix_arg), exist_ok=True)
-    #else:
+    # else:
     #    mock_makedirs.assert_not_called()

--- a/commec/tests/test_json.py
+++ b/commec/tests/test_json.py
@@ -1,68 +1,77 @@
-import pytest
 from dataclasses import asdict
+
+import pytest
+
 from commec.config.json_io import *
 from commec.config.result import *
 from commec.tools.search_handler import SearchToolVersion
 
+
 @pytest.fixture
 def test_screendata():
-    '''Fixture to provide the ScreenResult for testing.'''
+    """Fixture to provide the ScreenResult for testing."""
     return ScreenResult(
-        #recommendation="PASS",
-        commec_info = ScreenRunInfo(
+        # recommendation="PASS",
+        commec_info=ScreenRunInfo(
             commec_version="0.1.2",
             json_output_version=JSON_COMMEC_FORMAT_VERSION,
             time_taken="00:00:00:00",
             date_run="1.1.2024",
-            search_tool_info= SearchToolInfo(
-                biorisk_search_info=SearchToolVersion("HMM 0.0.0","DB 0.0.0"),
-                protein_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-                nucleotide_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-                low_concern_protein_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-                low_concern_rna_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-                low_concern_dna_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-            )
+            search_tool_info=SearchToolInfo(
+                biorisk_search_info=SearchToolVersion("HMM 0.0.0", "DB 0.0.0"),
+                protein_search_info=SearchToolVersion("Blast 0.0.0", "DB 0.0.0"),
+                nucleotide_search_info=SearchToolVersion("Blast 0.0.0", "DB 0.0.0"),
+                low_concern_protein_search_info=SearchToolVersion(
+                    "Blast 0.0.0", "DB 0.0.0"
+                ),
+                low_concern_rna_search_info=SearchToolVersion(
+                    "Blast 0.0.0", "DB 0.0.0"
+                ),
+                low_concern_dna_search_info=SearchToolVersion(
+                    "Blast 0.0.0", "DB 0.0.0"
+                ),
+            ),
         ),
-        query_info = ScreenQueryInfo(
-            file="no file",
-            number_of_queries=1,
-            total_query_length=10
+        query_info=ScreenQueryInfo(
+            file="no file", number_of_queries=1, total_query_length=10
         ),
-        queries= {
-            "Query1":
-            QueryResult(
+        queries={
+            "Query1": QueryResult(
                 query="Query1",
                 length=10,
-                status = QueryScreenStatus(),
-                hits = {
-                    "ImportantProtein1":
-                    HitResult(
-                        recommendation=HitScreenStatus(ScreenStatus.WARN, ScreenStep.BIORISK),
+                status=QueryScreenStatus(),
+                hits={
+                    "ImportantProtein1": HitResult(
+                        recommendation=HitScreenStatus(
+                            ScreenStatus.WARN, ScreenStep.BIORISK
+                        ),
                         name="ImportantProtein1",
-                        annotations = {"domain" : ["Bacteria"]},
-                        ranges = [
+                        annotations={"domain": ["Bacteria"]},
+                        ranges=[
                             MatchRange(
-                                e_value = 0.0,
-                                match_start = 0,
-                                match_end = 10,
-                                query_start = 0,
-                                query_end = 10
+                                e_value=0.0,
+                                match_start=0,
+                                match_end=10,
+                                query_start=0,
+                                query_end=10,
                             )
-                        ]
+                        ],
                     )
-                }
+                },
             )
         },
     )
 
+
 @pytest.fixture
 def empty_screendata():
-    '''Fixture to provide the ScreenResult for testing.'''
+    """Fixture to provide the ScreenResult for testing."""
     return ScreenResult()
 
-@pytest.mark.parametrize("test_data_fixture",["test_screendata", "empty_screendata"])
+
+@pytest.mark.parametrize("test_data_fixture", ["test_screendata", "empty_screendata"])
 def test_json_io(tmp_path, request, test_data_fixture):
-    ''' Test to ensure that read/write for JSON ScreenResult I/O is working correctly.'''
+    """Test to ensure that read/write for JSON ScreenResult I/O is working correctly."""
     test_data = request.getfixturevalue(test_data_fixture)
     json_filename1 = tmp_path / "testread1.json"
     json_filename2 = tmp_path / "testread2.json"
@@ -85,8 +94,9 @@ def test_json_io(tmp_path, request, test_data_fixture):
         f"Test JSON output data: \n{asdict(test_data_retrieved)}"
     )
 
+
 def test_erroneous_info(tmp_path, test_screendata):
-    ''' Test to ensure that read/write for JSON ScreenResult I/O is working correctly.'''
+    """Test to ensure that read/write for JSON ScreenResult I/O is working correctly."""
     test_data = test_screendata
     json_filename3 = tmp_path / "testread3.json"
     json_filename4 = tmp_path / "testread4.json"
@@ -98,8 +108,12 @@ def test_erroneous_info(tmp_path, test_screendata):
     test_data_dict = asdict(test_data_retrieved)
     test_data_dict["ExtraStuff1"] = "ExtraBitStuff1"
     test_data_dict["queries"]["Query1"]["ExtraStuff2"] = "ExtraBitStuff2"
-    test_data_dict["queries"]["Query1"]["hits"]["ImportantProtein1"]["ranges"].append("ExtraStuff3")
-    test_data_dict["queries"]["Query1"]["hits"]["ImportantProtein1"]["ranges"].append({"ExtraDictStuff4" : 9999})
+    test_data_dict["queries"]["Query1"]["hits"]["ImportantProtein1"]["ranges"].append(
+        "ExtraStuff3"
+    )
+    test_data_dict["queries"]["Query1"]["hits"]["ImportantProtein1"]["ranges"].append(
+        {"ExtraDictStuff4": 9999}
+    )
     test_data_dict2 = encode_dict_to_screen_data(test_data_dict)
     encode_screen_data_to_json(test_data_dict2, json_filename4)
     test_data_retrieved = get_screen_data_from_json(json_filename4)
@@ -111,19 +125,24 @@ def test_erroneous_info(tmp_path, test_screendata):
         f"Test JSON output data: \n{asdict(test_data_retrieved)}\n\n\n\n"
     )
 
+
 def test_recommendation_ordering():
     assert ScreenStatus.PASS.importance < ScreenStatus.FLAG.importance
     assert compare(ScreenStatus.PASS, ScreenStatus.FLAG) == ScreenStatus.FLAG
+
 
 def test_adding_data_to_existing():
     """
     Tests to ensure the mutability of writing to queries is working as expected.
     """
-    def write_info(input_query : QueryResult):
+
+    def write_info(input_query: QueryResult):
         input_query.status.biorisk = ScreenStatus.PASS
-    
+
     new_screen_data = ScreenResult()
-    new_screen_data.queries["test01"] = QueryResult("test01", "description01", 10, ScreenStatus.FLAG)
+    new_screen_data.queries["test01"] = QueryResult(
+        "test01", "description01", 10, ScreenStatus.FLAG
+    )
     write_query = new_screen_data.get_query("test01")
     write_info(write_query)
     assert new_screen_data.queries["test01"].status.biorisk == ScreenStatus.PASS

--- a/commec/tests/test_nc_to_nt.py
+++ b/commec/tests/test_nc_to_nt.py
@@ -1,12 +1,14 @@
 import pytest
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+
 from commec.config.query import Query, QueryValueError
+
 
 @pytest.fixture
 def seq_record():
     """
-    Fixture to generate a SeqRecord with 
+    Fixture to generate a SeqRecord with
     defined coding ('t') and non-coding ('a') regions.
     Total size = 150
     non-coding regions = 100
@@ -20,6 +22,7 @@ def seq_record():
     sequence = non_coding_1 + coding_1 + non_coding_2 + coding_2 + non_coding_3
     return SeqRecord(Seq(sequence), id="test_seq", description="")
 
+
 @pytest.fixture
 def non_coding_regions():
     """
@@ -27,11 +30,12 @@ def non_coding_regions():
     Uses the same lengths as in seq_record() to compute (start, end) values.
     """
     regions = [
-        (1, 50),       # First 'a' region
-        (71, 100),     # Second 'a' region (starts after first coding region)
-        (131, 150)     # Third 'a' region (starts after second coding region)
+        (1, 50),  # First 'a' region
+        (71, 100),  # Second 'a' region (starts after first coding region)
+        (131, 150),  # Third 'a' region (starts after second coding region)
     ]
     return regions
+
 
 # 0 based coordinates:
 # NT COORDS: 0 - 49    50 - 69   70 - 99   100 - 129   130 - 149
@@ -40,6 +44,7 @@ def non_coding_regions():
 # 1 based coordinates:
 # NT COORDS: 1 - 50    51 - 70   71 - 100   101 - 130   131 - 150
 # NC COORDS: 1 - 50              51 -  80                81 - 100
+
 
 @pytest.fixture
 def test_cases():
@@ -58,12 +63,13 @@ def test_cases():
         (100, 150),
     ]
 
+
 def test_coordinate_conversion(seq_record, non_coding_regions, test_cases):
     """
     Placeholder test function for coordinate conversion.
     """
     # Query setup
-    test_query : Query = Query(seq_record)
+    test_query: Query = Query(seq_record)
     test_query.non_coding_regions = non_coding_regions
 
     # Test Correct coords:
@@ -72,7 +78,7 @@ def test_coordinate_conversion(seq_record, non_coding_regions, test_cases):
 
     # Test Failure out of bounds.
     try:
-        _x = test_query.nc_to_nt_query_coords(test_cases[-1][0]+1)
+        _x = test_query.nc_to_nt_query_coords(test_cases[-1][0] + 1)
         assert False
     except QueryValueError:
         assert True
@@ -83,4 +89,3 @@ def test_coordinate_conversion(seq_record, non_coding_regions, test_cases):
         assert False
     except QueryValueError:
         assert True
-

--- a/commec/tests/test_query.py
+++ b/commec/tests/test_query.py
@@ -1,11 +1,14 @@
 import os
-import pytest
 import textwrap
+
+import pytest
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+
 from commec.config.query import Query, QueryTranslation
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
+
 
 def test_get_frame_length():
     # 11 nt query
@@ -25,6 +28,7 @@ def test_get_frame_length():
     assert 15 == query._get_frame_length(frame_offset=0)
     assert 15 == query._get_frame_length(frame_offset=1)
     assert 12 == query._get_frame_length(frame_offset=2)
+
 
 def test_translate_to_file(tmp_path):
     query = Query(SeqRecord(Seq("atgtgccatgg"), id="test"))
@@ -88,7 +92,6 @@ def test_translate():
     # 15nt query
     query = Query(SeqRecord(Seq("acgcacctgatcgct"), id="test"))
 
-
     # Input sequence: acgcacctgatcgct
     # Translations:
     # Frame   Pos     Codon split              Translation
@@ -150,9 +153,11 @@ def test_ambigious():
     | GTV   | V=A/C/G   | GTA, GTC, GTG      | Val        |
     """
     # 11nt query
-    #query = Query(SeqRecord(Seq("atntnccatgg"), id="test"))
-    #query = Query(SeqRecord(Seq("ATGAARTAYGCNAAYGARACNABGGADCAHGAVACNTGG"), id="test"))
-    query = Query(SeqRecord(Seq("ATGAARTAYGCNAAYGARACMCCSGGWGTKATHGTDCCBGTV"), id="test"))
+    # query = Query(SeqRecord(Seq("atntnccatgg"), id="test"))
+    # query = Query(SeqRecord(Seq("ATGAARTAYGCNAAYGARACNABGGADCAHGAVACNTGG"), id="test"))
+    query = Query(
+        SeqRecord(Seq("ATGAARTAYGCNAAYGARACMCCSGGWGTKATHGTDCCBGTV"), id="test")
+    )
 
     expected_translations = [
         QueryTranslation(frame=1, sequence="MKYANETPGVIVPV"),
@@ -170,12 +175,18 @@ def test_ambigious():
 @pytest.mark.parametrize(
     "input, expected_output",
     [
-        ("short_query_name","short_query_name"),
-        ("longquerynamewithnotokenstosplitonwowlookhowlongitistruelysomethingtobehold","longquerynamewithnotokenstosplitonwowlookhowlongitistruelysometh"),
-        ("long_query_name_with_common_tokens_to_split_on_wow_look_how_long_it_is_truly_something_to_behold", "long_query_name_with_common_tokens_to_split_on_wow_look_how_long")
+        ("short_query_name", "short_query_name"),
+        (
+            "longquerynamewithnotokenstosplitonwowlookhowlongitistruelysomethingtobehold",
+            "longquerynamewithnotokenstosplitonwowlookhowlongitistruelysometh",
+        ),
+        (
+            "long_query_name_with_common_tokens_to_split_on_wow_look_how_long_it_is_truly_something_to_behold",
+            "long_query_name_with_common_tokens_to_split_on_wow_look_how_long",
+        ),
     ],
 )
 def test_query_id_creation(input, expected_output):
-    """ Small tests to ensure the ID creation works to create IDS < 25 characters."""
+    """Small tests to ensure the ID creation works to create IDS < 25 characters."""
     output = Query.create_id(input)
     assert output == expected_output

--- a/commec/tests/test_query.py
+++ b/commec/tests/test_query.py
@@ -1,6 +1,4 @@
-from io import StringIO
 import os
-import pandas as pd
 import pytest
 import textwrap
 from Bio.Seq import Seq

--- a/commec/tests/test_rationales.py
+++ b/commec/tests/test_rationales.py
@@ -2,38 +2,50 @@
 Unit tests for controlled rationale outcomes
 """
 
-from commec.tests.screen_factory import (
-    ScreenTesterFactory,
-    ScreenStep
-)
-from commec.config.result import ScreenStatus, Rationale
-from commec.config.constants import MINIMUM_QUERY_LENGTH, MAXIMUM_QUERY_LENGTH
+from commec.config.constants import MAXIMUM_QUERY_LENGTH, MINIMUM_QUERY_LENGTH
+from commec.config.result import Rationale, ScreenStatus
+from commec.tests.screen_factory import ScreenStep, ScreenTesterFactory
 
 
 def test_hmmer(tmp_path):
     """
-    When there are hits to Biorisk with a large E-value, but no other hits, and we 
+    When there are hits to Biorisk with a large E-value, but no other hits, and we
      are running in the skip taxonomy mode, we correctly label the outcome
      as warning, however the rationale is set to "Matches to ." instead of
      the correct Rationale text indicating no hits.
     """
     screen_test = ScreenTesterFactory("low_evalue_hmmer", tmp_path)
-    screen_test.add_query("query1",1200)
-    screen_test.add_hit(ScreenStep.BIORISK, "query1", 100, 200, "HighEvalueHit", "HEH", 500, regulated=True, evalue = 100.0)
+    screen_test.add_query("query1", 1200)
+    screen_test.add_hit(
+        ScreenStep.BIORISK,
+        "query1",
+        100,
+        200,
+        "HighEvalueHit",
+        "HEH",
+        500,
+        regulated=True,
+        evalue=100.0,
+    )
     result = screen_test.run("--skip-tx")
     assert result.queries["query1"].status.screen_status == ScreenStatus.WARN
     assert result.queries["query1"].status.rationale == str(Rationale.NO_HITS_SKIP_NOTE)
 
+
 def test_skip_rationales(tmp_path):
     """
-    Ensure when a skip occurs due to query length, 
-    the rationale and screen status are correct. 
+    Ensure when a skip occurs due to query length,
+    the rationale and screen status are correct.
     """
     screen_test = ScreenTesterFactory("low_evalue_hmmer", tmp_path)
-    screen_test.add_query("query1",MINIMUM_QUERY_LENGTH - 1)
-    screen_test.add_query("query2",MAXIMUM_QUERY_LENGTH + 1)
+    screen_test.add_query("query1", MINIMUM_QUERY_LENGTH - 1)
+    screen_test.add_query("query2", MAXIMUM_QUERY_LENGTH + 1)
     result = screen_test.run()
     assert result.queries["query1"].status.screen_status == ScreenStatus.SKIP_SHORT
     assert result.queries["query2"].status.screen_status == ScreenStatus.SKIP_LONG
-    assert result.queries["query1"].status.rationale == str(Rationale.SKIPPED) + " " + str(Rationale.TOO_SHORT)
-    assert result.queries["query2"].status.rationale == str(Rationale.SKIPPED) + " " + str(Rationale.TOO_LONG)
+    assert result.queries["query1"].status.rationale == str(
+        Rationale.SKIPPED
+    ) + " " + str(Rationale.TOO_SHORT)
+    assert result.queries["query2"].status.rationale == str(
+        Rationale.SKIPPED
+    ) + " " + str(Rationale.TOO_LONG)

--- a/commec/tests/test_screen.py
+++ b/commec/tests/test_screen.py
@@ -6,17 +6,19 @@ Functional tests for commec screen.
 
 import os
 from dataclasses import asdict
-from commec.config.json_io import get_screen_data_from_json, encode_screen_data_to_json
-from commec.utils.json_html_output import generate_html_from_screen_data
-from commec.config.result import ScreenResult, ScreenStep, ScreenStatus
+
+from commec.config.json_io import encode_screen_data_to_json, get_screen_data_from_json
+from commec.config.result import ScreenResult, ScreenStatus, ScreenStep
 from commec.tests.screen_factory import ScreenTesterFactory
+from commec.utils.json_html_output import generate_html_from_screen_data
 
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
+
 
 def sanitize_for_test(screen_result: ScreenResult):
     """
     Remove arbitrary changes to the JSON that may arise during testing but are not
-    relevant and should not be compared or versioned. 
+    relevant and should not be compared or versioned.
     """
     # Runtime for pytest may be different
     screen_result.commec_info.time_taken = None
@@ -28,6 +30,7 @@ def sanitize_for_test(screen_result: ScreenResult):
     # Pytest increments the filename version, so ignore the input file.
     screen_result.query_info.file = "/test_placeholder/"
 
+
 def test_functional_screen(tmp_path, request):
     """
     Rewrite of the functional test using ScreenTestFactory
@@ -35,36 +38,274 @@ def test_functional_screen(tmp_path, request):
     # File directories
     html_output_path = os.path.join(os.path.dirname(__file__), "test_data/functional")
     json_output_path = tmp_path / "functional.output.json"
-    expected_json_output_path = os.path.join(os.path.dirname(__file__), "test_data/functional.json")
+    expected_json_output_path = os.path.join(
+        os.path.dirname(__file__), "test_data/functional.json"
+    )
 
     # Screen Test Factory
     functional_test = ScreenTesterFactory("functional", tmp_path)
     functional_test.add_query("FCTEST1", 600)
 
-    #Biorisk
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 7, 95, "Toxin1a", "ShouldntClear", 11111, description="LargeAreaFlag", score = 500, regulated = True, superkingdom = "Viruses", species = "horriblus", evalue = 1e-21)
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 34, 65, "Toxin1b", "ShouldntClear", 22222, description="SmallImportantFlag", score = 1000, regulated = True, superkingdom = "Viruses", species = "extra-horriblus", evalue = 1e-22)
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 49, 80, "Toxin1c", "ShouldTrim", 33333, description="SmallUnimportantTRIM", score = 100, regulated = True, superkingdom = "Viruses", species = "unimporticus", evalue = 1e-23)
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 109, 191, "Toxin2", "ShouldWarn", 22222, description="WarningExample",score = 1000, regulated = False, superkingdom = "Viruses", species = "extra-horriblus-factor", evalue = 1e-24)
-    functional_test.add_hit(ScreenStep.BIORISK, "FCTEST1", 593, 505, "Toxin3", "ShouldWarn", 11111, description="ReverseExample", score = 500, regulated = False, superkingdom = "Viruses", species = "horriblus-factor", evalue = 1e-25)
+    # Biorisk
+    functional_test.add_hit(
+        ScreenStep.BIORISK,
+        "FCTEST1",
+        7,
+        95,
+        "Toxin1a",
+        "ShouldntClear",
+        11111,
+        description="LargeAreaFlag",
+        score=500,
+        regulated=True,
+        superkingdom="Viruses",
+        species="horriblus",
+        evalue=1e-21,
+    )
+    functional_test.add_hit(
+        ScreenStep.BIORISK,
+        "FCTEST1",
+        34,
+        65,
+        "Toxin1b",
+        "ShouldntClear",
+        22222,
+        description="SmallImportantFlag",
+        score=1000,
+        regulated=True,
+        superkingdom="Viruses",
+        species="extra-horriblus",
+        evalue=1e-22,
+    )
+    functional_test.add_hit(
+        ScreenStep.BIORISK,
+        "FCTEST1",
+        49,
+        80,
+        "Toxin1c",
+        "ShouldTrim",
+        33333,
+        description="SmallUnimportantTRIM",
+        score=100,
+        regulated=True,
+        superkingdom="Viruses",
+        species="unimporticus",
+        evalue=1e-23,
+    )
+    functional_test.add_hit(
+        ScreenStep.BIORISK,
+        "FCTEST1",
+        109,
+        191,
+        "Toxin2",
+        "ShouldWarn",
+        22222,
+        description="WarningExample",
+        score=1000,
+        regulated=False,
+        superkingdom="Viruses",
+        species="extra-horriblus-factor",
+        evalue=1e-24,
+    )
+    functional_test.add_hit(
+        ScreenStep.BIORISK,
+        "FCTEST1",
+        593,
+        505,
+        "Toxin3",
+        "ShouldWarn",
+        11111,
+        description="ReverseExample",
+        score=500,
+        regulated=False,
+        superkingdom="Viruses",
+        species="horriblus-factor",
+        evalue=1e-25,
+    )
     # Protein Taxonomy
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 320, 380, "NR_HIT_ShouldntClear", "NR_HIT_FLAG1", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.06)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 410, 490, "ShouldClearBySynBio", "NR_HIT_FLAG2", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.07)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 410, 500, "NR_HIT2_ShouldntClear", "NR_HIT_FLAG3", "12345", regulated = True, superkingdom = "Viruses", species = "regulaticus", evalue = 0.08)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 310, 370, "ShouldClear", "NR_HIT_FLAG4", "12346", regulated = True, superkingdom = "Viruses", species = "fine-icus", evalue = 0.09)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixedReg1", "NR_HIT_MIXED1", "12347", regulated = True, superkingdom = "Viruses", species = "danger-poop", evalue = 0.10)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixednonReg2", "NR_HIT_MIXED2", "12348", regulated = False, superkingdom = "Bacteria", species = "cute-happy-bacter", evalue = 0.11)
-    functional_test.add_hit(ScreenStep.TAXONOMY_AA, "FCTEST1", 340, 390, "ShouldMixedNonReg3", "NR_HIT_MIXED3", "12349", regulated = False, superkingdom = "Bacteria", species = "poopicus", evalue = 0.12)
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "FCTEST1",
+        320,
+        380,
+        "NR_HIT_ShouldntClear",
+        "NR_HIT_FLAG1",
+        "12345",
+        regulated=True,
+        superkingdom="Viruses",
+        species="regulaticus",
+        evalue=0.06,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "FCTEST1",
+        410,
+        490,
+        "ShouldClearBySynBio",
+        "NR_HIT_FLAG2",
+        "12345",
+        regulated=True,
+        superkingdom="Viruses",
+        species="regulaticus",
+        evalue=0.07,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "FCTEST1",
+        410,
+        500,
+        "NR_HIT2_ShouldntClear",
+        "NR_HIT_FLAG3",
+        "12345",
+        regulated=True,
+        superkingdom="Viruses",
+        species="regulaticus",
+        evalue=0.08,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "FCTEST1",
+        310,
+        370,
+        "ShouldClear",
+        "NR_HIT_FLAG4",
+        "12346",
+        regulated=True,
+        superkingdom="Viruses",
+        species="fine-icus",
+        evalue=0.09,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "FCTEST1",
+        340,
+        390,
+        "ShouldMixedReg1",
+        "NR_HIT_MIXED1",
+        "12347",
+        regulated=True,
+        superkingdom="Viruses",
+        species="danger-poop",
+        evalue=0.10,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "FCTEST1",
+        340,
+        390,
+        "ShouldMixednonReg2",
+        "NR_HIT_MIXED2",
+        "12348",
+        regulated=False,
+        superkingdom="Bacteria",
+        species="cute-happy-bacter",
+        evalue=0.11,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "FCTEST1",
+        340,
+        390,
+        "ShouldMixedNonReg3",
+        "NR_HIT_MIXED3",
+        "12349",
+        regulated=False,
+        superkingdom="Bacteria",
+        species="poopicus",
+        evalue=0.12,
+    )
     # Nucleotide Taxonomy
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 220, 280, "SUBJECT_1", "NT_HIT_FLAG1", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.13)
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 110, 190, "SUBJECT_2", "NT_HIT_FLAG2", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.14)
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 110, 200, "SUBJECT_3", "NT_HIT_FLAG3", "12350", regulated = True, superkingdom = "Viruses", evalue = 0.15)
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 310, 390, "Main", "NT_HIT_MIXED", "12345", regulated = True, superkingdom = "Viruses", evalue = 0.16)
-    functional_test.add_hit(ScreenStep.TAXONOMY_NT, "FCTEST1", 310, 390, "NonRegMixedWithMain", "NT_HIT_MIXED2", "12346", regulated = False, superkingdom = "Bacteria", evalue = 0.17)
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_NT,
+        "FCTEST1",
+        220,
+        280,
+        "SUBJECT_1",
+        "NT_HIT_FLAG1",
+        "12345",
+        regulated=True,
+        superkingdom="Viruses",
+        evalue=0.13,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_NT,
+        "FCTEST1",
+        110,
+        190,
+        "SUBJECT_2",
+        "NT_HIT_FLAG2",
+        "12345",
+        regulated=True,
+        superkingdom="Viruses",
+        evalue=0.14,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_NT,
+        "FCTEST1",
+        110,
+        200,
+        "SUBJECT_3",
+        "NT_HIT_FLAG3",
+        "12350",
+        regulated=True,
+        superkingdom="Viruses",
+        evalue=0.15,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_NT,
+        "FCTEST1",
+        310,
+        390,
+        "Main",
+        "NT_HIT_MIXED",
+        "12345",
+        regulated=True,
+        superkingdom="Viruses",
+        evalue=0.16,
+    )
+    functional_test.add_hit(
+        ScreenStep.TAXONOMY_NT,
+        "FCTEST1",
+        310,
+        390,
+        "NonRegMixedWithMain",
+        "NT_HIT_MIXED2",
+        "12346",
+        regulated=False,
+        superkingdom="Bacteria",
+        evalue=0.17,
+    )
     # Low Concern
-    functional_test.add_hit(ScreenStep.LOW_CONCERN_PROTEIN, "FCTEST1", 202, 370, "BENIGNPROT", "Benign1", description = "BenignHMMClear", evalue = 1e-26)
-    functional_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "FCTEST1", 50, 150, "BENIGNRNA", "12346", description = "BenignCMTestOutput", evalue = 1e-27)
-    functional_test.add_hit(ScreenStep.LOW_CONCERN_DNA, "FCTEST1", 410, 480, "BENIGNSYNBIO", "210", description = "BenignBlastClear", evalue = 1e-28)
+    functional_test.add_hit(
+        ScreenStep.LOW_CONCERN_PROTEIN,
+        "FCTEST1",
+        202,
+        370,
+        "BENIGNPROT",
+        "Benign1",
+        description="BenignHMMClear",
+        evalue=1e-26,
+    )
+    functional_test.add_hit(
+        ScreenStep.LOW_CONCERN_RNA,
+        "FCTEST1",
+        50,
+        150,
+        "BENIGNRNA",
+        "12346",
+        description="BenignCMTestOutput",
+        evalue=1e-27,
+    )
+    functional_test.add_hit(
+        ScreenStep.LOW_CONCERN_DNA,
+        "FCTEST1",
+        410,
+        480,
+        "BENIGNSYNBIO",
+        "210",
+        description="BenignBlastClear",
+        evalue=1e-28,
+    )
 
     result = functional_test.run()
 
@@ -74,8 +315,10 @@ def test_functional_screen(tmp_path, request):
         encode_screen_data_to_json(result, expected_json_output_path)
 
     # Test results vs expected results.
-    expected_screen_result : ScreenResult = get_screen_data_from_json(expected_json_output_path)
-    actual_screen_result : ScreenResult = get_screen_data_from_json(json_output_path)
+    expected_screen_result: ScreenResult = get_screen_data_from_json(
+        expected_json_output_path
+    )
+    actual_screen_result: ScreenResult = get_screen_data_from_json(json_output_path)
     sanitize_for_test(expected_screen_result)
     sanitize_for_test(actual_screen_result)
 
@@ -88,67 +331,218 @@ def test_functional_screen(tmp_path, request):
         " or if new output is expected, run with --gen-examples\n"
     )
 
+
 def test_screen_factory(tmp_path):
     my_factory = ScreenTesterFactory("test_01", tmp_path)
     my_factory.add_query("query_01", 500)
-    my_factory.add_hit(ScreenStep.BIORISK, "query_01", 99, 399, "bad_risk", "BR500", 200, regulated = True)
-    my_factory.add_hit(ScreenStep.TAXONOMY_AA, "query_01", 100, 300, "reg_gene", "ACC500", 500, "imaginary_species", regulated = True)
-    my_factory.add_hit(ScreenStep.TAXONOMY_NT, "query_01", 1, 90, "reg_gene2", "ACC501", 501, "imaginary_species", regulated = True)
-    my_factory.add_hit(ScreenStep.LOW_CONCERN_PROTEIN, "query_01", 97, 402, "safe_protein", "SF21YKN", 256, "safeicius")
-    my_factory.add_hit(ScreenStep.LOW_CONCERN_DNA, "query_01", 97, 402, "safe_dna", "SF22YKN", 256, "safeicius")
-    my_factory.add_hit(ScreenStep.LOW_CONCERN_RNA, "query_01", 97, 402, "safe_rna", "SF23YKN", 256, "safeicius")
+    my_factory.add_hit(
+        ScreenStep.BIORISK,
+        "query_01",
+        99,
+        399,
+        "bad_risk",
+        "BR500",
+        200,
+        regulated=True,
+    )
+    my_factory.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query_01",
+        100,
+        300,
+        "reg_gene",
+        "ACC500",
+        500,
+        "imaginary_species",
+        regulated=True,
+    )
+    my_factory.add_hit(
+        ScreenStep.TAXONOMY_NT,
+        "query_01",
+        1,
+        90,
+        "reg_gene2",
+        "ACC501",
+        501,
+        "imaginary_species",
+        regulated=True,
+    )
+    my_factory.add_hit(
+        ScreenStep.LOW_CONCERN_PROTEIN,
+        "query_01",
+        97,
+        402,
+        "safe_protein",
+        "SF21YKN",
+        256,
+        "safeicius",
+    )
+    my_factory.add_hit(
+        ScreenStep.LOW_CONCERN_DNA,
+        "query_01",
+        97,
+        402,
+        "safe_dna",
+        "SF22YKN",
+        256,
+        "safeicius",
+    )
+    my_factory.add_hit(
+        ScreenStep.LOW_CONCERN_RNA,
+        "query_01",
+        97,
+        402,
+        "safe_rna",
+        "SF23YKN",
+        256,
+        "safeicius",
+    )
     result = my_factory.run()
     assert result.queries["query_01"].status.screen_status == ScreenStatus.FLAG
     assert result.queries["query_01"].status.biorisk == ScreenStatus.FLAG
-    assert result.queries["query_01"].status.protein_taxonomy == ScreenStatus.CLEARED_FLAG
+    assert (
+        result.queries["query_01"].status.protein_taxonomy == ScreenStatus.CLEARED_FLAG
+    )
     assert result.queries["query_01"].status.nucleotide_taxonomy == ScreenStatus.FLAG
     assert result.queries["query_01"].status.low_concern == ScreenStatus.FLAG
 
+
 def test_low_concern_multiquery(tmp_path):
     """
-    Checks that the low concern hits are correctly accessed when multiple queries are used, and 
+    Checks that the low concern hits are correctly accessed when multiple queries are used, and
     the low concern databases have multiple hits across all queries.
     """
     screen_test = ScreenTesterFactory("lowconcern_multiquerycheck", tmp_path)
     screen_test.add_query("query1", 1000)
     screen_test.add_query("query2", 1000)
     screen_test.add_query("query3", 1000)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 400, 600, "ClearMe", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query2", 400, 600, "ClearMe", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query3", 400, 600, "ClearMe", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query1", 100, 900, "ClearProtein", "RR55CLEAR", 500)
-    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query2", 100, 900, "ClearProtein", "RR55CLEAR", 500)
-    screen_test.add_hit(ScreenStep.LOW_CONCERN_RNA, "query3", 100, 900, "ClearProtein", "RR55CLEAR", 500)
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query1",
+        400,
+        600,
+        "ClearMe",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query2",
+        400,
+        600,
+        "ClearMe",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query3",
+        400,
+        600,
+        "ClearMe",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.LOW_CONCERN_RNA, "query1", 100, 900, "ClearProtein", "RR55CLEAR", 500
+    )
+    screen_test.add_hit(
+        ScreenStep.LOW_CONCERN_RNA, "query2", 100, 900, "ClearProtein", "RR55CLEAR", 500
+    )
+    screen_test.add_hit(
+        ScreenStep.LOW_CONCERN_RNA, "query3", 100, 900, "ClearProtein", "RR55CLEAR", 500
+    )
     result = screen_test.run()
 
     assert result.queries["query1"].status.screen_status == ScreenStatus.CLEARED_FLAG
     assert result.queries["query2"].status.screen_status == ScreenStatus.CLEARED_FLAG
     assert result.queries["query3"].status.screen_status == ScreenStatus.CLEARED_FLAG
 
+
 def test_different_regions(tmp_path):
     """
     Creates a single hit, with many regions, then a single clear on one of those regions.
     The low concern hit should only clear a single region, and not the whole query.
-    Final result should be FLAG. 
+    Final result should be FLAG.
     Tests that hits with multiple regions are being cleared correctly.
     """
     screen_test = ScreenTesterFactory("repeating_taxonomy", tmp_path)
-    screen_test.add_query("query1",1000)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 30, 90, "RegRepeat", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 100, 170, "RegRepeat", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 190, 260, "RegRepeat", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 300, 390, "RegRepeat", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.TAXONOMY_AA, "query1", 400, 750, "RegRepeat", "RR55", 500, regulated=True)
-    screen_test.add_hit(ScreenStep.LOW_CONCERN_PROTEIN, "query1", 400, 750, "ClearProtein", "RR55CLEAR", 500)
+    screen_test.add_query("query1", 1000)
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query1",
+        30,
+        90,
+        "RegRepeat",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query1",
+        100,
+        170,
+        "RegRepeat",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query1",
+        190,
+        260,
+        "RegRepeat",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query1",
+        300,
+        390,
+        "RegRepeat",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.TAXONOMY_AA,
+        "query1",
+        400,
+        750,
+        "RegRepeat",
+        "RR55",
+        500,
+        regulated=True,
+    )
+    screen_test.add_hit(
+        ScreenStep.LOW_CONCERN_PROTEIN,
+        "query1",
+        400,
+        750,
+        "ClearProtein",
+        "RR55CLEAR",
+        500,
+    )
     result = screen_test.run()
 
-    #encode_screen_data_to_json(result, "../test_output.json")
+    # encode_screen_data_to_json(result, "../test_output.json")
 
     num_hits = len(result.queries["query1"].hits)
     num_regions = len(result.queries["query1"].hits["RegRepeat"].ranges)
     status = result.queries["query1"].status.screen_status
-    assert  num_hits == 2, f"Expected two hits, got {num_hits}."
-    assert  num_regions == 5, (f"Number of ranges [{num_regions}] in hit `RegRepeat` for "
-                            " `query1` not equal to expected number (5).")
-    assert status == ScreenStatus.FLAG, ("Expected status is to FLAG, current status"
-                                        f" is {status}, likely multiple region clearing issue.")
+    assert num_hits == 2, f"Expected two hits, got {num_hits}."
+    assert num_regions == 5, (
+        f"Number of ranges [{num_regions}] in hit `RegRepeat` for "
+        " `query1` not equal to expected number (5)."
+    )
+    assert status == ScreenStatus.FLAG, (
+        "Expected status is to FLAG, current status"
+        f" is {status}, likely multiple region clearing issue."
+    )

--- a/commec/tests/test_screen_io.py
+++ b/commec/tests/test_screen_io.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 import os
 
 from commec.config.screen_io import ScreenIO, IoValidationError

--- a/commec/tests/test_screen_io.py
+++ b/commec/tests/test_screen_io.py
@@ -1,9 +1,10 @@
-import pytest
-from unittest.mock import patch
 import os
+from unittest.mock import patch
 
-from commec.config.screen_io import ScreenIO, IoValidationError
-from commec.screen import add_args, ScreenArgumentParser
+import pytest
+
+from commec.config.screen_io import IoValidationError, ScreenIO
+from commec.screen import ScreenArgumentParser, add_args
 
 
 @pytest.fixture

--- a/commec/tests/test_split.py
+++ b/commec/tests/test_split.py
@@ -1,7 +1,9 @@
 import os
 from unittest.mock import mock_open, patch
+
 import pytest
 from Bio import SeqIO
+
 from commec.split import clean_description, write_split_fasta
 
 

--- a/commec/tests/test_trim.py
+++ b/commec/tests/test_trim.py
@@ -9,6 +9,7 @@ The following behaviour is expected:
 
 import pandas as pd
 import pytest
+
 from commec.tools.hmmer import remove_overlaps
 
 # Test the following hmmer configuration:
@@ -20,31 +21,33 @@ from commec.tools.hmmer import remove_overlaps
 # 10------------------------------90 (different query)
 
 # Example DataFrame
-example_hmmer_01 = pd.DataFrame({
-    "query name": ["one","one","one","one","two", "two"],
-    "q. start": [10, 40, 20, 10, 20, 10],
-    "q. end":   [50, 60, 40, 50, 30, 90],
-    "score":    [3, 5, 6, 1, 1, 2]
-})
+example_hmmer_01 = pd.DataFrame(
+    {
+        "query name": ["one", "one", "one", "one", "two", "two"],
+        "q. start": [10, 40, 20, 10, 20, 10],
+        "q. end": [50, 60, 40, 50, 30, 90],
+        "score": [3, 5, 6, 1, 1, 2],
+    }
+)
 
 # Example DataFrame
-example_hmmer_01_output = pd.DataFrame({
-    "query name": ["one","one", "one", "two"],
-    "q. start": [10, 40, 20, 10],
-    "q. end":   [50, 60, 40, 90],
-    "score":    [3, 5, 6, 2]
-})
+example_hmmer_01_output = pd.DataFrame(
+    {
+        "query name": ["one", "one", "one", "two"],
+        "q. start": [10, 40, 20, 10],
+        "q. end": [50, 60, 40, 90],
+        "score": [3, 5, 6, 2],
+    }
+)
+
 
 @pytest.mark.parametrize(
     "input_hmmer, expected_output_hmmer",
     [
         (example_hmmer_01, example_hmmer_01_output),
-    ]
+    ],
 )
-def test_hmmer_overlaps(
-    input_hmmer : pd.DataFrame,
-    expected_output_hmmer : pd.DataFrame
-):
+def test_hmmer_overlaps(input_hmmer: pd.DataFrame, expected_output_hmmer: pd.DataFrame):
     """
     Checks common configurations that require trimming in Hmmer outputs,
     In particular partial overlaps, full encapsulations, score differences, and different queries.

--- a/commec/tools/blast_tools.py
+++ b/commec/tools/blast_tools.py
@@ -6,18 +6,22 @@ Useful for reading any blast related outputs, for example from Blastx, Blastn, o
 
 Also contains the abstract base class for blastX/N/Diamond database search handlers.
 """
-import os
+
 import logging
+import os
 from typing import BinaryIO, TextIO
-import pytaxonkit
-import pandas as pd
+
 import numpy as np
+import pandas as pd
+import pytaxonkit
+
 from commec.tools.search_handler import SearchHandler
 
 TAXID_SYNTHETIC_CONSTRUCTS = 32630
 TAXID_VECTORS = 29278
 
 logger = logging.getLogger(__name__)
+
 
 class BlastHandler(SearchHandler):
     """
@@ -30,6 +34,7 @@ class BlastHandler(SearchHandler):
         if self.has_hits():
             output_dataframe = read_blast(self.out_file)
         return output_dataframe
+
 
 def _split_by_tax_id(blast: pd.DataFrame, taxids_col_name="subject tax ids"):
     """
@@ -63,7 +68,9 @@ def get_lineages(taxids: pd.Series, db_path: str | os.PathLike, threads: int):
     any regulated pathogen, since pathogens might be regulated at various points in the lineage
     (i.e. not just species or genus).
     """
-    lin = pytaxonkit.lineage(taxids.drop_duplicates(), data_dir=db_path, threads=threads)
+    lin = pytaxonkit.lineage(
+        taxids.drop_duplicates(), data_dir=db_path, threads=threads
+    )
 
     # Warn about error codes from lineage search
     taxids_not_found = lin[lin["Code"] == -1]["TaxID"]
@@ -196,8 +203,12 @@ def read_blast(blast_file: str | os.PathLike | BinaryIO | TextIO) -> pd.DataFram
     blast.columns = columns
     blast = blast.sort_values(by=["% identity"], ascending=False)
     blast["log evalue"] = -np.log10(pd.to_numeric(blast["evalue"]) + 1e-300)
-    blast["q. coverage"] = abs(blast["q. end"] - blast["q. start"]) / blast["query length"].max()
-    blast["s. coverage"] = abs(blast["s. end"] - blast["s. start"]) / blast["subject length"]
+    blast["q. coverage"] = (
+        abs(blast["q. end"] - blast["q. start"]) / blast["query length"].max()
+    )
+    blast["s. coverage"] = (
+        abs(blast["s. end"] - blast["s. start"]) / blast["subject length"]
+    )
     blast["query acc."] = blast["query acc."].astype(str)
 
     blast = blast[blast["subject tax ids"].notna()]
@@ -245,6 +256,7 @@ def _trim_overlapping(blast: pd.DataFrame):
 
     return blast2
 
+
 def shift_hits_pos_strand(blast):
     for j in blast.index:
         if blast.loc[j, "q. start"] > blast.loc[j, "q. end"]:
@@ -254,7 +266,8 @@ def shift_hits_pos_strand(blast):
             blast.loc[j, "q. end"] = end
     return blast
 
-def _trim_edges(df : pd.DataFrame) -> tuple[pd.DataFrame, int]:
+
+def _trim_edges(df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
     """
     Function for filtering a Blast derived dataframe, removes weaker hits
     (based on % identity) that have extents within that of stronger hits.
@@ -269,22 +282,24 @@ def _trim_edges(df : pd.DataFrame) -> tuple[pd.DataFrame, int]:
     """
 
     assert "q. start" in df.columns, (
-        "Expected column \"q. start\" does not exist for _trim_edges().\n"
+        'Expected column "q. start" does not exist for _trim_edges().\n'
         f"Existing columns: {', '.join(df.columns)}"
     )
 
     assert "q. end" in df.columns, (
-        "Expected column \"q. end\" does not exist for _trim_edges().\n"
+        'Expected column "q. end" does not exist for _trim_edges().\n'
         f"Existing columns: {', '.join(df.columns)}"
     )
 
     assert "% identity" in df.columns, (
-        "Expected column \"query length\" does not exist for _trim_edges().\n"
+        'Expected column "query length" does not exist for _trim_edges().\n'
         f"Existing columns: {', '.join(df.columns)}"
     )
 
     for top, i in enumerate(df.index):  # run through each hit from the top
-        for _, j in enumerate(df.index[top + 1:], start=top + 1):  # compare to each below
+        for _, j in enumerate(
+            df.index[top + 1 :], start=top + 1
+        ):  # compare to each below
             i_start = df.loc[i, "q. start"]
             i_end = df.loc[i, "q. end"]
             j_start = df.loc[j, "q. start"]
@@ -298,7 +313,10 @@ def _trim_edges(df : pd.DataFrame) -> tuple[pd.DataFrame, int]:
                 # if the hit extends past the end of the earlier one
                 elif i_end + 1 < j_end:
                     df.loc[j, "q. start"] = i_end + 1
-                elif i_end == j_end and df.loc[j, "% identity"] == df.loc[i, "% identity"]:
+                elif (
+                    i_end == j_end
+                    and df.loc[j, "% identity"] == df.loc[i, "% identity"]
+                ):
                     pass
                 # remove if the hit is contained in the earlier one
                 else:
@@ -312,7 +330,10 @@ def _trim_edges(df : pd.DataFrame) -> tuple[pd.DataFrame, int]:
                     pass
                 elif i_start - 1 > j_start:
                     df.loc[j, "q. end"] = i_start - 1
-                elif i_start == j_start and df.loc[j, "% identity"] == df.loc[i, "% identity"]:
+                elif (
+                    i_start == j_start
+                    and df.loc[j, "% identity"] == df.loc[i, "% identity"]
+                ):
                     pass
                 else:
                     df.loc[j, "q. start"] = 0
@@ -345,7 +366,9 @@ def get_top_hits(blast: pd.DataFrame):
     Trim BLAST results down to the top hit for each base.
     """
 
-    assert isinstance(blast, pd.DataFrame), "get_top_hits expects a pandas dataframe object."
+    assert isinstance(blast, pd.DataFrame), (
+        "get_top_hits expects a pandas dataframe object."
+    )
 
     if blast.empty:
         logger.debug("Empty dataframe passed to Get Top Hits.")

--- a/commec/tools/blastn.py
+++ b/commec/tools/blastn.py
@@ -6,11 +6,12 @@ Initialise with local input database, fasta to screen, and output file.
 Throws error if inputs are invalid. Creates a temporary log file, which is deleted on completion.
 """
 
-import os
 import glob
+import os
 import subprocess
+
 from commec.tools.blast_tools import BlastHandler
-from commec.tools.search_handler import SearchToolVersion, DatabaseValidationError
+from commec.tools.search_handler import DatabaseValidationError, SearchToolVersion
 
 
 class BlastNHandler(BlastHandler):
@@ -20,7 +21,11 @@ class BlastNHandler(BlastHandler):
     """
 
     def __init__(
-        self, database_file: str, input_file: str, out_file: str, **kwargs,
+        self,
+        database_file: str,
+        input_file: str,
+        out_file: str,
+        **kwargs,
     ):
         super().__init__(database_file, input_file, out_file, **kwargs)
         # We fill this with defaults, however they can always be overridden before screening.

--- a/commec/tools/blastx.py
+++ b/commec/tools/blastx.py
@@ -6,11 +6,12 @@ Initialise with local input database, fasta to screen, and output file.
 Throws error if inputs are invalid. Creates a temporary log file, which is deleted on completion.
 """
 
-import os
 import glob
+import os
 import subprocess
+
 from commec.tools.blast_tools import BlastHandler
-from commec.tools.search_handler import SearchToolVersion, DatabaseValidationError
+from commec.tools.search_handler import DatabaseValidationError, SearchToolVersion
 
 
 class BlastXHandler(BlastHandler):
@@ -20,7 +21,11 @@ class BlastXHandler(BlastHandler):
     """
 
     def __init__(
-        self, database_file: str, input_file: str, out_file: str, **kwargs,
+        self,
+        database_file: str,
+        input_file: str,
+        out_file: str,
+        **kwargs,
     ):
         super().__init__(database_file, input_file, out_file, **kwargs)
         # We fill this with defaults, however they can always be overridden before screening.

--- a/commec/tools/cmscan.py
+++ b/commec/tools/cmscan.py
@@ -6,9 +6,12 @@ Additional methods for reading handler output, readcmscan, which returns a panda
 Instantiate a CmscanHandler, with input local database, input fasta, and output file.
 Throws if inputs are invalid. Creates a temporary log file, which is deleted on completion.
 """
-import subprocess
+
 import re
+import subprocess
+
 import pandas as pd
+
 from commec.config.constants import CMSCAN_MAX_THREAD_LIMIT
 from commec.tools.search_handler import SearchHandler, SearchToolVersion
 
@@ -29,21 +32,22 @@ class CmscanHandler(SearchHandler):
             self.input_file,
         ]
         self.run_as_subprocess(command, self.temp_log_file)
-    
+
     def read_output(self):
         output_dataframe = readcmscan(self.out_file)
         # Standardize the output column names to be like blast:
-        output_dataframe = output_dataframe.rename(columns={
-            "seq from": "q. start",
-            "seq to": "q. end",
-            "coverage": "q. coverage",
-            "target name": "subject title",
-            "mdl from": "s. start",
-            "mdl to" : "s. end",
-            'E-value': "evalue",
-        })
+        output_dataframe = output_dataframe.rename(
+            columns={
+                "seq from": "q. start",
+                "seq to": "q. end",
+                "coverage": "q. coverage",
+                "target name": "subject title",
+                "mdl from": "s. start",
+                "mdl to": "s. end",
+                "E-value": "evalue",
+            }
+        )
         return output_dataframe
- 
 
     def get_version_information(self) -> SearchToolVersion:
         try:
@@ -56,11 +60,13 @@ class CmscanHandler(SearchHandler):
                     # Early exit if data has been found
                     if database_info:
                         break
-            
+
             result = subprocess.run(
                 ["cmscan", "-h"], capture_output=True, text=True, check=True
             )
-            tool_info = result.stdout.splitlines()[1].strip()[2:] or "error retrieving info"
+            tool_info = (
+                result.stdout.splitlines()[1].strip()[2:] or "error retrieving info"
+            )
 
             return SearchToolVersion(tool_info, database_info or "error")
 

--- a/commec/tools/diamond.py
+++ b/commec/tools/diamond.py
@@ -6,17 +6,19 @@ Instantiate a DiamondHnadler, with input local database, input fasta, and output
 Alter member variables after instantiation to change behaviour, before calling search().
 Throws if inputs are invalid. Creates a temporary log file, which is deleted on completion.
 """
-import os
+
 import glob
-import subprocess
 import logging
+import os
+import subprocess
 from math import gcd as greatest_common_denominator
 from multiprocessing import Pool
 
 from commec.tools.blast_tools import BlastHandler
-from commec.tools.search_handler import SearchToolVersion, DatabaseValidationError
+from commec.tools.search_handler import DatabaseValidationError, SearchToolVersion
 
 logger = logging.getLogger(__name__)
+
 
 class DiamondHandler(BlastHandler):
     """
@@ -65,10 +67,7 @@ class DiamondHandler(BlastHandler):
                 " Directory path can be set via --databases option or --config yaml."
             )
         prefix = self.db_file[:-5] if self.db_file.endswith(".dmnd") else self.db_file
-        if not (
-            os.path.isfile(f"{prefix}.dmnd")
-            or glob.glob(f"{prefix}.[0-9]*.dmnd")
-        ):
+        if not (os.path.isfile(f"{prefix}.dmnd") or glob.glob(f"{prefix}.[0-9]*.dmnd")):
             raise DatabaseValidationError(
                 f"No Diamond database files found for prefix '{prefix}'."
                 " Expected <prefix>.dmnd or <prefix>.<N>.dmnd in the database directory."
@@ -88,7 +87,6 @@ class DiamondHandler(BlastHandler):
                 f"Screening database directory {self.db_directory} "
                 f"contains no databases matching the pattern: {db_suffix}"
                 " Screening directory path can be set via --databases option or --config yaml."
-
             )
 
     def run_diamond_search(self, args):
@@ -98,14 +96,22 @@ class DiamondHandler(BlastHandler):
         log_file = f"{self.temp_log_file}_{db_index}"
 
         command = [
-            "diamond", "blastx", "--quiet",
-            "-d", db_file,
-            "--threads", str(self.threads_per_run),
-            "-q", self.input_file,
-            "-o", output_file,
-            "--frameshift", str(self.frameshift),
-            "--outfmt", self.output_format,
-            *self.output_format_tokens
+            "diamond",
+            "blastx",
+            "--quiet",
+            "-d",
+            db_file,
+            "--threads",
+            str(self.threads_per_run),
+            "-q",
+            self.input_file,
+            "-o",
+            output_file,
+            "--frameshift",
+            str(self.frameshift),
+            "--outfmt",
+            self.output_format,
+            *self.output_format_tokens,
         ]
         if self.do_range_culling:
             command.append("--range-culling")
@@ -124,9 +130,8 @@ class DiamondHandler(BlastHandler):
             n_concurrent_runs = self.jobs
         else:
             n_concurrent_runs = greatest_common_denominator(
-                number_of_databases,
-                max_threads
-                )
+                number_of_databases, max_threads
+            )
 
         if number_of_databases < n_concurrent_runs:
             logger.warning(
@@ -191,9 +196,13 @@ class DiamondHandler(BlastHandler):
             pool.map(self.run_diamond_search, enumerate(self.db_files, 1))
 
         # Concatenate all output files, and remove the temporary ones.
-        temp_outfiles = (f"{self.out_file}.{i}.tsv" for i in range(1, len(self.db_files) + 1))
+        temp_outfiles = (
+            f"{self.out_file}.{i}.tsv" for i in range(1, len(self.db_files) + 1)
+        )
         self.concatenate_concurrent_outputs(self.out_file, temp_outfiles)
-        temp_logfiles = (f"{self.temp_log_file}_{i}" for i in range(1, len(self.db_files) + 1))
+        temp_logfiles = (
+            f"{self.temp_log_file}_{i}" for i in range(1, len(self.db_files) + 1)
+        )
         self.concatenate_concurrent_outputs(self.temp_log_file, temp_logfiles)
 
     def warn_if_nonoptimal_cpu_utilization(self, n_diamond_dbs):
@@ -228,7 +237,7 @@ class DiamondHandler(BlastHandler):
                 self.concurrent_runs,
                 self.threads_per_run,
                 n_diamond_dbs,
-                self.concurrent_runs
+                self.concurrent_runs,
             )
 
     def concatenate_concurrent_outputs(self, base_filename, temp_files):

--- a/commec/tools/fetch_nc_bits.py
+++ b/commec/tools/fetch_nc_bits.py
@@ -6,12 +6,8 @@ Fetch parts of a query that had no high-quality protein matches for use in nuclo
 Usage:
     fetch_nc_bits.py query_name fasta_file_path
 """
-import argparse
 import logging
-import shutil
-import re
 import pandas as pd
-from Bio import SeqIO
 from commec.config.query import Query
 from commec.tools.blast_tools import get_high_identity_hits
 from commec.tools.search_handler import SearchHandler

--- a/commec/tools/fetch_nc_bits.py
+++ b/commec/tools/fetch_nc_bits.py
@@ -6,32 +6,36 @@ Fetch parts of a query that had no high-quality protein matches for use in nuclo
 Usage:
     fetch_nc_bits.py query_name fasta_file_path
 """
+
 import logging
+
 import pandas as pd
+
 from commec.config.query import Query
+from commec.config.result import ScreenStatus
 from commec.tools.blast_tools import get_high_identity_hits
 from commec.tools.search_handler import SearchHandler
-from commec.config.result import ScreenStatus
 
 logger = logging.getLogger(__name__)
 
-def _get_ranges_with_no_hits(input_df : pd.DataFrame):
+
+def _get_ranges_with_no_hits(input_df: pd.DataFrame):
     """
     Get indices not covered by the query start / end ranges in the BLAST results.
     """
 
     assert "q. start" in input_df.columns, (
-        "Column \"q. start\" does not exist for get_ranges_with_no_hits().\n"
+        'Column "q. start" does not exist for get_ranges_with_no_hits().\n'
         f"Existing columns: {', '.join(input_df.columns)}"
     )
 
     assert "q. end" in input_df.columns, (
-        "Column \"q. end\" does not exist for get_ranges_with_no_hits().\n"
+        'Column "q. end" does not exist for get_ranges_with_no_hits().\n'
         f"Existing columns: {', '.join(input_df.columns)}"
     )
 
     assert "query length" in input_df.columns, (
-        "Column \"query length\" does not exist for get_ranges_with_no_hits().\n"
+        'Column "query length" does not exist for get_ranges_with_no_hits().\n'
         f"Existing columns: {', '.join(input_df.columns)}"
     )
 
@@ -47,14 +51,14 @@ def _get_ranges_with_no_hits(input_df : pd.DataFrame):
     # union of hits, not pairwise. This handles nested and partially-overlapping
     # hits correctly (e.g. a lower-identity hit that extends beyond a stronger
     # one on either side).
-    merged : list[list[int]] = []
+    merged: list[list[int]] = []
     for start, end in hit_ranges:
         if merged and start <= merged[-1][1] + 1:
             merged[-1][1] = max(merged[-1][1], end)
         else:
             merged.append([start, end])
 
-    nc_ranges : list[tuple[int,int]] = []
+    nc_ranges: list[tuple[int, int]] = []
     query_length = int(input_df["query length"].iloc[0])
 
     # Include the start if the first hit begins more than 50 bp after the start
@@ -75,14 +79,15 @@ def _get_ranges_with_no_hits(input_df : pd.DataFrame):
 
     return nc_ranges
 
-def _set_no_coding_regions(query : Query):
+
+def _set_no_coding_regions(query: Query):
     """Set the query to be entirely non-coding (i.e. no high-quality protein hits)."""
     query.non_coding_regions.append((1, query.length))
 
+
 def calculate_noncoding_regions_per_query(
-        protein_search_handler : SearchHandler,
-        queries : dict[str, Query]
-        ):
+    protein_search_handler: SearchHandler, queries: dict[str, Query]
+):
     """
     Fetch noncoding regions > 50bp for every query, and
     updates the Query dictionary to include non-coding meta-data.
@@ -100,22 +105,32 @@ def calculate_noncoding_regions_per_query(
     query_col = "query acc."
 
     for query in queries.values():
-        protein_hits_for_query = protein_hits[protein_hits[query_col] == query.name].copy()
+        protein_hits_for_query = protein_hits[
+            protein_hits[query_col] == query.name
+        ].copy()
 
         if protein_hits_for_query.empty:
-            logger.info("No protein hits found for %s, screening entire sequence.", query.name)
+            logger.info(
+                "No protein hits found for %s, screening entire sequence.", query.name
+            )
             _set_no_coding_regions(query)
             continue
 
         # Correcting query length in nc coordinate output.
         protein_hits_for_query.loc[:, "q.len"] = query.length
 
-        logger.debug("\t --> Protein hits found for %s, fetching nt regions not covered by a 90%% ID hit or better", query.name)
+        logger.debug(
+            "\t --> Protein hits found for %s, fetching nt regions not covered by a 90%% ID hit or better",
+            query.name,
+        )
 
         ranges_to_screen = _get_ranges_with_no_hits(protein_hits_for_query)
         # if the entire sequence, save regions <50 bases, is covered with protein, skip nt scan
         if not ranges_to_screen:
-            logger.info("\t --> no noncoding regions >= 50 bases found for %s, skipping nt scan for query.", query.name)
+            logger.info(
+                "\t --> no noncoding regions >= 50 bases found for %s, skipping nt scan for query.",
+                query.name,
+            )
             query.result.status.nucleotide_taxonomy = ScreenStatus.SKIP
             continue
 
@@ -123,4 +138,8 @@ def calculate_noncoding_regions_per_query(
         query.non_coding_regions.extend(ranges_to_screen)
 
         ranges_str = ", ".join(f"{start}-{end}" for start, end in ranges_to_screen)
-        logger.info("\t --> Identified noncoding regions for query %s: [%s]", query.name, ranges_str)
+        logger.info(
+            "\t --> Identified noncoding regions for query %s: [%s]",
+            query.name,
+            ranges_str,
+        )

--- a/commec/tools/hmmer.py
+++ b/commec/tools/hmmer.py
@@ -6,10 +6,13 @@ Additional methods for reading hmmscan output, readhmmer, which returns a pandas
 Instantiate a HmmerHandler, with input local database, input fasta, and output file.
 Throws if inputs are invalid. Creates a temporary log file, which is deleted on completion.
 """
+
+import itertools
 import re
 import subprocess
+
 import pandas as pd
-import itertools
+
 from commec.config.constants import HMMSCAN_MAX_THREAD_LIMIT
 from commec.config.query import Query
 from commec.tools.search_handler import SearchHandler, SearchToolVersion
@@ -36,16 +39,18 @@ class HmmerHandler(SearchHandler):
     def read_output(self):
         output_dataframe = readhmmer(self.out_file)
         # Standardize the output column names to be like blast:
-        output_dataframe = output_dataframe.rename(columns={
-            #"ali from": "q. start", # These are no re-calculated to Query NT coordinates.
-            #"ali to": "q. end",
-            "coverage": "q. coverage",
-            "target name": "subject title",
-            "qlen":"query length",
-            "hmm from":"s. start",
-            "hmm to":"s. end",
-            'E-value': "evalue",
-        })
+        output_dataframe = output_dataframe.rename(
+            columns={
+                # "ali from": "q. start", # These are no re-calculated to Query NT coordinates.
+                # "ali to": "q. end",
+                "coverage": "q. coverage",
+                "target name": "subject title",
+                "qlen": "query length",
+                "hmm from": "s. start",
+                "hmm to": "s. end",
+                "E-value": "evalue",
+            }
+        )
         return output_dataframe
 
     def get_version_information(self) -> SearchToolVersion:
@@ -125,49 +130,59 @@ def readhmmer(fileh):
     hmmer["qlen"] = pd.to_numeric(hmmer["qlen"])
     hmmer["query name"] = hmmer["query name"].astype(str)
     # Extract the frame information.
-    hmmer["frame"] = hmmer["query name"].str.split('_').str[-1].astype(int)
+    hmmer["frame"] = hmmer["query name"].str.split("_").str[-1].astype(int)
     return hmmer
 
-def remove_overlaps(hmmer : pd.DataFrame) -> pd.DataFrame:
+
+def remove_overlaps(hmmer: pd.DataFrame) -> pd.DataFrame:
     """
-    Trims verbosity of a HMMER output, 
-    by removing weaker hits which are 
+    Trims verbosity of a HMMER output,
+    by removing weaker hits which are
     encompassed in their extent by higher scoring hits.
 
-    Note, works to trim nucleotide coordinates relative to the query, 
+    Note, works to trim nucleotide coordinates relative to the query,
     not ali from and ali to from the HMMER itself.
 
     This means it can be used on any DataFrame with the q. start and q. end NT headings.
     (Consider moving to a general coordinates tool function?)
     """
-    assert "q. start" in hmmer.columns, ("No \"q. start\" heading in HMMER output dataframe being "
-                                         "passed to remove overlaps, ensure that the dataframe has "
-                                         "been processed for converstion to nucleotide coordinates.")
+    assert "q. start" in hmmer.columns, (
+        'No "q. start" heading in HMMER output dataframe being '
+        "passed to remove overlaps, ensure that the dataframe has "
+        "been processed for converstion to nucleotide coordinates."
+    )
 
-    assert "q. end" in hmmer.columns, ("No \"q. end\" heading in HMMER output dataframe being "
-                                         "passed to remove overlaps, ensure that the dataframe has "
-                                         "been processed for converstion to nucleotide coordinates.")
+    assert "q. end" in hmmer.columns, (
+        'No "q. end" heading in HMMER output dataframe being '
+        "passed to remove overlaps, ensure that the dataframe has "
+        "been processed for converstion to nucleotide coordinates."
+    )
 
-    trimmed_hmmer = hmmer # Direct Assignment, reassigned later with .drop() for deep-copy.
+    trimmed_hmmer = (
+        hmmer  # Direct Assignment, reassigned later with .drop() for deep-copy.
+    )
 
     # Ensure all logic is performed per unique Query name.
     for query in hmmer["query name"].unique():
-
         hmmer_for_query = hmmer[hmmer["query name"] == query]
-        sorted_values = hmmer_for_query.sort_values(by=["score"], ascending = False)
+        sorted_values = hmmer_for_query.sort_values(by=["score"], ascending=False)
 
         for i, j in itertools.combinations(sorted_values.index, 2):
             # If J is encapsulated:
-            if (sorted_values.loc[i, "q. start"] <= sorted_values.loc[j, "q. start"]
+            if (
+                sorted_values.loc[i, "q. start"] <= sorted_values.loc[j, "q. start"]
                 and sorted_values.loc[i, "q. end"] >= sorted_values.loc[j, "q. end"]
-                and sorted_values.loc[i, "score"] >= sorted_values.loc[j, "score"]):
+                and sorted_values.loc[i, "score"] >= sorted_values.loc[j, "score"]
+            ):
                 if j in trimmed_hmmer.index:
                     trimmed_hmmer = trimmed_hmmer.drop([j])
                     continue
             # If I is encapsulated:
-            if (sorted_values.loc[i, "q. start"] >= sorted_values.loc[j, "q. start"]
+            if (
+                sorted_values.loc[i, "q. start"] >= sorted_values.loc[j, "q. start"]
                 and sorted_values.loc[i, "q. end"] <= sorted_values.loc[j, "q. end"]
-                and sorted_values.loc[i, "score"] <= sorted_values.loc[j, "score"]):
+                and sorted_values.loc[i, "score"] <= sorted_values.loc[j, "score"]
+            ):
                 if i in trimmed_hmmer.index:
                     trimmed_hmmer = trimmed_hmmer.drop([i])
 
@@ -176,23 +191,28 @@ def remove_overlaps(hmmer : pd.DataFrame) -> pd.DataFrame:
 
     return trimmed_hmmer
 
-def recalculate_hmmer_query_coordinates(hmmer : pd.DataFrame):
+
+def recalculate_hmmer_query_coordinates(hmmer: pd.DataFrame):
     """
     Recalculate the coordinates of the hmmer database , such that each translated frame
     reverts to original nucleotide coordinates.
     """
-    assert "nt_qlen" in hmmer.columns, ("No \"nt_qlen\" heading in HMMER output dataframe being "
-                                         "passed to calculate nt coordinates, ensure that the dataframe has "
-                                         "been processed to include nucleotide query length data.")
+    assert "nt_qlen" in hmmer.columns, (
+        'No "nt_qlen" heading in HMMER output dataframe being '
+        "passed to calculate nt coordinates, ensure that the dataframe has "
+        "been processed to include nucleotide query length data."
+    )
     hmmer["q. start"], hmmer["q. end"] = convert_protein_to_nucleotide_coords(
         hmmer["frame"].to_numpy(),
         hmmer["ali from"].to_numpy(),
         hmmer["ali to"].to_numpy(),
-        hmmer["nt_qlen"].to_numpy())
+        hmmer["nt_qlen"].to_numpy(),
+    )
 
-def append_nt_querylength_info(hmmer : pd.DataFrame, queries : dict[str, Query]):
-    """ 
-    Take the hmmer output, and add a series (nt_qlen) 
+
+def append_nt_querylength_info(hmmer: pd.DataFrame, queries: dict[str, Query]):
+    """
+    Take the hmmer output, and add a series (nt_qlen)
     of the true nt length based on query name.
     """
     hmmer["nt_qlen"] = [queries[q[:-2]].length for q in hmmer["query name"]]

--- a/commec/tools/search_handler.py
+++ b/commec/tools/search_handler.py
@@ -3,13 +3,15 @@
 """
 Abstract base class defining a shared interface for search tools.
 """
-from abc import ABC, abstractmethod
-import os
-from dataclasses import dataclass
-import subprocess
+
 import logging
+import os
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
+
 
 @dataclass
 class SearchToolVersion:
@@ -21,6 +23,7 @@ class SearchToolVersion:
 
 class DatabaseValidationError(Exception):
     """Custom exception for database validation errors."""
+
 
 class SearchHandler(ABC):
     """
@@ -64,8 +67,8 @@ class SearchHandler(ABC):
         self.db_file = os.path.abspath(os.path.expanduser(database_file))
         self.input_file = os.path.abspath(os.path.expanduser(input_file))
         self.out_file = os.path.abspath(os.path.expanduser(out_file))
-        self.threads = self._apply_thread_cap(kwargs.get('threads', 1))
-        self.force = kwargs.get('force', False)
+        self.threads = self._apply_thread_cap(kwargs.get("threads", 1))
+        self.force = kwargs.get("force", False)
         self.arguments_dictionary = {}
         self.successful = True
 
@@ -97,10 +100,12 @@ class SearchHandler(ABC):
         Wrapper for _search, skipping if existing output should not be overwritten.
         """
         if self.should_use_existing_output:
-            logger.warning("%s expected output data already exists, "
-                         "will use existing data found in:",
-                         self.__class__.__name__)
-            logger.warning(self.out_file, extra = {"no_prefix" : True, "cap":True})
+            logger.warning(
+                "%s expected output data already exists, "
+                "will use existing data found in:",
+                self.__class__.__name__,
+            )
+            logger.warning(self.out_file, extra={"no_prefix": True, "cap": True})
         else:
             self._search()
 
@@ -199,7 +204,7 @@ class SearchHandler(ABC):
         self.successful = False
 
         logger.debug("SUBPROCESS: %s", " ".join(command))
-        logger.debug(" ".join(command), extra = {"no_prefix":True,"cap":True})
+        logger.debug(" ".join(command), extra={"no_prefix": True, "cap": True})
 
         with open(out_file, "a", encoding="utf-8") as f:
             result = subprocess.run(
@@ -217,7 +222,7 @@ class SearchHandler(ABC):
                     f"subprocess.run of command '{command_str}' encountered error."
                     f" Check {out_file} for logs."
                 )
-            
+
         self.successful = True
 
     def __del__(self):

--- a/commec/utils/concat_seqs.py
+++ b/commec/utils/concat_seqs.py
@@ -6,6 +6,7 @@ Script that concatenates all sequences in a FASTA file.
 Usage:
     concat_seqs.py input.fasta
 """
+
 import sys
 
 # read in the file based on the command line argument

--- a/commec/utils/coordinates.py
+++ b/commec/utils/coordinates.py
@@ -1,14 +1,12 @@
 """
-Helper functions associated with the handling of 
+Helper functions associated with the handling of
 basepair|amino-acid, nucleotide|peptide coordinate systems.
 """
 
 import numpy as np
 
-def convert_protein_to_nucleotide_coords(frame,
-                                         protein_start,
-                                         protein_end,
-                                         seq_length):
+
+def convert_protein_to_nucleotide_coords(frame, protein_start, protein_end, seq_length):
     """
     Convert protein coordinates to nucleotide coordinates considering the reading frame.
 
@@ -38,8 +36,12 @@ def convert_protein_to_nucleotide_coords(frame,
 
     # Forward frames (1, 2, 3)
     forward_mask = frame <= 3
-    nucleotide_start[forward_mask] = (protein_start[forward_mask] * 3) + (frame[forward_mask] - 1)
-    nucleotide_end[forward_mask] = (protein_end[forward_mask] * 3) + 2 + (frame[forward_mask] - 1)
+    nucleotide_start[forward_mask] = (protein_start[forward_mask] * 3) + (
+        frame[forward_mask] - 1
+    )
+    nucleotide_end[forward_mask] = (
+        (protein_end[forward_mask] * 3) + 2 + (frame[forward_mask] - 1)
+    )
 
     # Reverse frames (4, 5, 6)
     reverse_mask = frame > 3
@@ -47,8 +49,12 @@ def convert_protein_to_nucleotide_coords(frame,
     nuc_start_reverse = (protein_start[reverse_mask] * 3) + (reverse_frame - 1)
     nuc_end_reverse = (protein_end[reverse_mask] * 3) + 2 + (reverse_frame - 1)
 
-    nucleotide_start[reverse_mask] = seq_length[reverse_mask] - nuc_end_reverse - 1 + reverse_offset[reverse_mask]
-    nucleotide_end[reverse_mask] = seq_length[reverse_mask] - nuc_start_reverse - 1 + reverse_offset[reverse_mask]
+    nucleotide_start[reverse_mask] = (
+        seq_length[reverse_mask] - nuc_end_reverse - 1 + reverse_offset[reverse_mask]
+    )
+    nucleotide_end[reverse_mask] = (
+        seq_length[reverse_mask] - nuc_start_reverse - 1 + reverse_offset[reverse_mask]
+    )
 
     # Convert to back to 1-based coordinates for reporting.
     nucleotide_start += 1

--- a/commec/utils/dict_utils.py
+++ b/commec/utils/dict_utils.py
@@ -4,12 +4,13 @@
 Static functions useful for dealing with common dictionary tasks.
 """
 
+
 @staticmethod
-def deep_update(to_update: dict[str, any], 
-                has_updates: dict[str, any],
-                accept_new_keys: bool = False) -> tuple[
-                    dict[str,any], 
-                    list[tuple[str,any]]]:
+def deep_update(
+    to_update: dict[str, any],
+    has_updates: dict[str, any],
+    accept_new_keys: bool = False,
+) -> tuple[dict[str, any], list[tuple[str, any]]]:
     """
     Recursively update a nested dictionary without completely overwriting nested dictionaries.
     Only already existing keys are updated. Any keys not existing in the dictionary
@@ -24,16 +25,22 @@ def deep_update(to_update: dict[str, any],
     Outputs:
     * updated : dict[str, any] a copy of the to_update dictionary, with values
     from any matching keys overridden by has_updates.
-    * rejected : list[tuple[str,any] A list of the rejected key value pairs, i.e. 
+    * rejected : list[tuple[str,any] A list of the rejected key value pairs, i.e.
     keys present in has_updates, but not present in to_update.
     """
     rejected = []
     updated = to_update.copy()
     for key, value in has_updates.items():
         # If both values are dictionaries, recursively update
-        if key in updated and isinstance(updated[key], dict) and isinstance(value, dict):
-            accept_next : bool = (key == "base_paths")
-            updated[key], additional_rejects = deep_update(updated[key], value, accept_next)
+        if (
+            key in updated
+            and isinstance(updated[key], dict)
+            and isinstance(value, dict)
+        ):
+            accept_next: bool = key == "base_paths"
+            updated[key], additional_rejects = deep_update(
+                updated[key], value, accept_next
+            )
             rejected.extend(additional_rejects)
         # If not a dictionary, just copy the value, forced if required.
         elif key in updated or accept_new_keys:

--- a/commec/utils/file_utils.py
+++ b/commec/utils/file_utils.py
@@ -7,6 +7,7 @@ Static functions useful for dealing with common file parsing tasks.
 import argparse
 import os
 
+
 # Below go to config parameters.
 @staticmethod
 def directory_arg(path):
@@ -14,6 +15,7 @@ def directory_arg(path):
     if not os.path.isdir(path):
         raise argparse.ArgumentTypeError(f"{path} is not a valid directory path")
     return path
+
 
 @staticmethod
 def file_arg(path):
@@ -23,6 +25,7 @@ def file_arg(path):
     if not os.path.getsize(path) > 0:
         raise argparse.ArgumentTypeError(f"{path} is an empty file")
     return path
+
 
 @staticmethod
 def expand_and_normalize(path):

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -212,8 +212,8 @@ def update_layout(fig, query_to_draw: QueryResult, stacks):
     figure_base_height = 180
     figure_stack_height = 30
 
-    r, g, b = color_from_status(query_to_draw.status.screen_status)
-    css_color = f"rgb({r},{g},{b})"
+    # r, g, b = color_from_status(query_to_draw.status.screen_status)
+    # css_color = f"rgb({r},{g},{b})"
 
     fig.update_layout(showlegend=False)
     # Update layout to display X-axis on top and hide Y-axis labels for specified subplot

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -4,51 +4,57 @@ into a visual HTML representation of the Commec output. Which can be embedded in
 any other HTML document as appropriate.
 """
 
-import textwrap
 import argparse
-import os
-import plotly.graph_objects as go
-import pandas as pd
 import importlib.resources
+import os
+import textwrap
+
+import pandas as pd
+import plotly.graph_objects as go
 from mako.template import Template
 
 from commec.config.json_io import get_screen_data_from_json
 from commec.config.result import (
-    ScreenResult,
-    QueryResult,
     HitResult,
-    ScreenStep,
+    QueryResult,
+    ScreenResult,
     ScreenStatus,
+    ScreenStep,
 )
 
-class CommecPalette():
-    """ 
+
+class CommecPalette:
+    """
     Static Container for colours used in Commec.
     """
-    WHITE = [255,255,255]
-    DK_BLUE = [35,42,88]
-    LT_BLUE = [66,155,185]
-    ORANGE = [241,80,36]
+
+    WHITE = [255, 255, 255]
+    DK_BLUE = [35, 42, 88]
+    LT_BLUE = [66, 155, 185]
+    ORANGE = [241, 80, 36]
     # Yellow and Red are not official Commec colours.
-    YELLOW = [241,168,29]
-    RED = [207,27,81]
-    BLACK = [0,0,0]
+    YELLOW = [241, 168, 29]
+    RED = [207, 27, 81]
+    BLACK = [0, 0, 0]
 
     @staticmethod
-    def mod(modulate, alpha: int = 255, multiplier : float = 1.0) -> str:
-        m : float = multiplier
-        return str(f'rgba({round(modulate[0]*m)},{round(modulate[1]*m)},{round(modulate[2]*m)},{alpha})')
+    def mod(modulate, alpha: int = 255, multiplier: float = 1.0) -> str:
+        m: float = multiplier
+        return str(
+            f"rgba({round(modulate[0] * m)},{round(modulate[1] * m)},{round(modulate[2] * m)},{alpha})"
+        )
 
-    rgba_WHITE = 'rgba(255,255,255,255)'
-    rgba_DK_BLUE = 'rgba(35,42,88,255)'
-    rgba_LT_BLUE = 'rgba(66,155,185,255)'
-    rgba_ORANGE = 'rgba(241,80,36,255)'
+    rgba_WHITE = "rgba(255,255,255,255)"
+    rgba_DK_BLUE = "rgba(35,42,88,255)"
+    rgba_LT_BLUE = "rgba(66,155,185,255)"
+    rgba_ORANGE = "rgba(241,80,36,255)"
     # Yellow and Red are not official Commec colours,
-    rgba_YELLOW = 'rgba(241,80,36,255)'
-    rgba_RED = 'rgba(207,27,81,255)'
+    rgba_YELLOW = "rgba(241,80,36,255)"
+    rgba_RED = "rgba(207,27,81,255)"
 
-def color_from_status(status : ScreenStatus) -> CommecPalette:
-    """ 
+
+def color_from_status(status: ScreenStatus) -> CommecPalette:
+    """
     Convert a Screen step into an associated Colour.
     Previously, colours were based on step, now they are based on outcome.
     """
@@ -58,8 +64,9 @@ def color_from_status(status : ScreenStatus) -> CommecPalette:
         return CommecPalette.ORANGE
     return CommecPalette.LT_BLUE
 
-def color_from_hit(hit : HitResult) -> CommecPalette:
-    """ 
+
+def color_from_hit(hit: HitResult) -> CommecPalette:
+    """
     Convert a Screen step into an associated Colour.
     Previously, colours were based on step, now they are based on outcome.
     """
@@ -67,9 +74,11 @@ def color_from_hit(hit : HitResult) -> CommecPalette:
 
     if hit.recommendation.from_step == ScreenStep.BIORISK:
         return CommecPalette.RED
-    if (hit.recommendation.from_step == ScreenStep.LOW_CONCERN_PROTEIN or
-        hit.recommendation.from_step == ScreenStep.LOW_CONCERN_RNA or
-        hit.recommendation.from_step == ScreenStep.LOW_CONCERN_DNA):
+    if (
+        hit.recommendation.from_step == ScreenStep.LOW_CONCERN_PROTEIN
+        or hit.recommendation.from_step == ScreenStep.LOW_CONCERN_RNA
+        or hit.recommendation.from_step == ScreenStep.LOW_CONCERN_DNA
+    ):
         return CommecPalette.LT_BLUE
     if hit.recommendation.from_step == ScreenStep.TAXONOMY_AA:
         return CommecPalette.ORANGE
@@ -77,30 +86,32 @@ def color_from_hit(hit : HitResult) -> CommecPalette:
         return CommecPalette.YELLOW
     return CommecPalette.DK_BLUE
 
-def constrast_color_from_hit(hit : HitResult):
-    """ 
+
+def constrast_color_from_hit(hit: HitResult):
+    """
     Convert a Screen step into an associated Colour.
     This is now always white, which works well with all outcome colours.
     As this colour is meant for text, and not box objects, its associated
     allowed values are restricted to hex, or built-in strings.
     """
     return "#FFFFFF"
-    if (hit.recommendation.from_step == ScreenStep.TAXONOMY_NT):
+    if hit.recommendation.from_step == ScreenStep.TAXONOMY_NT:
         return "#000000"
     return "#FFFFFF"
 
-def overlay_text_from_hit(hit : HitResult):
+
+def overlay_text_from_hit(hit: HitResult):
     outcome = str(hit.recommendation.status)
     outcome = outcome.replace("Warning", "Warn")
-    outcome = outcome.replace("(Cleared)","")
+    outcome = outcome.replace("(Cleared)", "")
     step = hit.recommendation.from_step
     match step:
         case ScreenStep.BIORISK:
-            return "Biorisk "+outcome
+            return "Biorisk " + outcome
         case ScreenStep.TAXONOMY_AA:
-            return "Protein "+outcome
+            return "Protein " + outcome
         case ScreenStep.TAXONOMY_NT:
-            return "Nucl. "+outcome
+            return "Nucl. " + outcome
         case ScreenStep.LOW_CONCERN_PROTEIN:
             return "Low Concern Protein"
         case ScreenStep.LOW_CONCERN_RNA:
@@ -108,9 +119,10 @@ def overlay_text_from_hit(hit : HitResult):
         case ScreenStep.LOW_CONCERN_DNA:
             return "Low Concern DNA"
 
-def generate_html_from_screen_data(input_data : ScreenResult, output_file : str):
+
+def generate_html_from_screen_data(input_data: ScreenResult, output_file: str):
     """
-    Interpret the ScreenResult from Commec Screen output as a visualisation, in 
+    Interpret the ScreenResult from Commec Screen output as a visualisation, in
     the form on an HTML output.
     If Commec Screen handled multiple Queries, then they are combined in the HTML output.
     """
@@ -118,39 +130,41 @@ def generate_html_from_screen_data(input_data : ScreenResult, output_file : str)
     figures_html = []
     query_toc = []
 
-    status_counts = {'flag': 0, 'warning': 0, 'pass': 0, 'error' : 0}
-    
+    status_counts = {"flag": 0, "warning": 0, "pass": 0, "error": 0}
+
     # Simply don't count skips or stops.
     NORMALISE_STATUS = {
-        ScreenStatus.NULL : "error",
-        #ScreenStatus.SKIP : "error",
-        #ScreenStatus.STOP : "error",
-        ScreenStatus.PASS : "pass",
-        ScreenStatus.CLEARED_FLAG : "pass",
-        ScreenStatus.CLEARED_WARN : "pass",
-        ScreenStatus.WARN : "warning",
-        ScreenStatus.FLAG : "flag",
-        ScreenStatus.ERROR : "error",
+        ScreenStatus.NULL: "error",
+        # ScreenStatus.SKIP : "error",
+        # ScreenStatus.STOP : "error",
+        ScreenStatus.PASS: "pass",
+        ScreenStatus.CLEARED_FLAG: "pass",
+        ScreenStatus.CLEARED_WARN: "pass",
+        ScreenStatus.WARN: "warning",
+        ScreenStatus.FLAG: "flag",
+        ScreenStatus.ERROR: "error",
     }
 
     # Render each query as its own Plotly HTML visualisation:
     for i, query in enumerate(input_data.queries.values()):
         fig = go.Figure()
-        vertical_stack_count : int = draw_query_to_plot(fig, query)
+        vertical_stack_count: int = draw_query_to_plot(fig, query)
         update_layout(fig, query, vertical_stack_count)
-        file_name = output_file.strip()+"_"+str(i)+".html"
-        html = fig.to_html(file_name, full_html = False, include_plotlyjs='cdn')
+        file_name = output_file.strip() + "_" + str(i) + ".html"
+        html = fig.to_html(file_name, full_html=False, include_plotlyjs="cdn")
         figures_html.append(html)
-        
+
         # Collect full query data for template
-        query_toc.append({
-            'name': query.query,
-            'description': query.description,
-            'status': query.status.screen_status,
-            'length': query.length,
-            'rationale': query.status.rationale
-        })
-        
+        query_toc.append(
+            {
+                "name": query.query,
+                "description": query.description,
+                "status": query.status.screen_status,
+                "length": query.length,
+                "rationale": query.status.rationale,
+            }
+        )
+
         # Count statuses
         bucket = NORMALISE_STATUS.get(query.status.screen_status)
         if bucket:
@@ -160,31 +174,37 @@ def generate_html_from_screen_data(input_data : ScreenResult, output_file : str)
     n_query = input_data.query_info.number_of_queries
     plural = "y" if n_query == 1 else "ies"
     html_title = f"Commec Screen Summary: {n_query} Quer{plural}."
-    
+
     # Extract basenames for template
-    input_filename = os.path.basename(input_data.query_info.file) if hasattr(input_data.query_info, 'file') else 'N/A'
+    input_filename = (
+        os.path.basename(input_data.query_info.file)
+        if hasattr(input_data.query_info, "file")
+        else "N/A"
+    )
 
     # Construct the composite HTML
-    template_path = str(importlib.resources.files("commec").joinpath("utils").joinpath("template.html"))
-    template = Template(filename = template_path)
+    template_path = str(
+        importlib.resources.files("commec").joinpath("utils").joinpath("template.html")
+    )
+    template = Template(filename=template_path)
     rendered_html = template.render(
-        figures_html=figures_html, 
+        figures_html=figures_html,
         page_title=html_title,
         commec_info=input_data.commec_info,
         query_info=input_data.query_info,
         query_toc=query_toc,
         input_filename=input_filename,
-        status_counts=status_counts
+        status_counts=status_counts,
     )
 
     # Save the combined HTML output
-    output_filename = output_file.strip()+".html"
-    with open(output_filename, "w", encoding = "utf-8") as output_file:
+    output_filename = output_file.strip() + ".html"
+    with open(output_filename, "w", encoding="utf-8") as output_file:
         output_file.write(rendered_html)
 
 
-def update_layout(fig, query_to_draw : QueryResult, stacks):
-    """ 
+def update_layout(fig, query_to_draw: QueryResult, stacks):
+    """
     Applies some default settings to the plotly figure,
     also adjusts the figure height based on the number of vertically stacking bars.
     """
@@ -192,42 +212,44 @@ def update_layout(fig, query_to_draw : QueryResult, stacks):
     figure_base_height = 180
     figure_stack_height = 30
 
-    r,g,b = color_from_status(query_to_draw.status.screen_status)
+    r, g, b = color_from_status(query_to_draw.status.screen_status)
     css_color = f"rgb({r},{g},{b})"
 
     fig.update_layout(showlegend=False)
     # Update layout to display X-axis on top and hide Y-axis labels for specified subplot
-    fig.update_layout({
-        # General layout properties
-        'height': figure_base_height + (figure_stack_height * stacks),
-        'barmode': 'overlay',
-        'template': 'plotly_white',
-        'plot_bgcolor': 'rgba(0,0,0,0)',  # Transparent plot area
-        'paper_bgcolor': 'rgba(0,0,0,0)',  # Transparent outer area
-        "xaxis": dict(
-            #title="Query Basepairs (bp)",
-            showline=True,
-            constrain="domain",
-            ticks='outside',
-            showgrid=True,
-            fixedrange=True,
-            zeroline=False,
-            side="top",
-        ),
-        "yaxis": dict(
-            title="",
-            showticklabels=False,
-            autorange='reversed',
-            range=[-0.5, stacks + 0.5],
-            fixedrange=True,
-            tickmode="linear",
-            zeroline=False,
-        ),
-        'bargap': 0.01,
-    })
+    fig.update_layout(
+        {
+            # General layout properties
+            "height": figure_base_height + (figure_stack_height * stacks),
+            "barmode": "overlay",
+            "template": "plotly_white",
+            "plot_bgcolor": "rgba(0,0,0,0)",  # Transparent plot area
+            "paper_bgcolor": "rgba(0,0,0,0)",  # Transparent outer area
+            "xaxis": dict(
+                # title="Query Basepairs (bp)",
+                showline=True,
+                constrain="domain",
+                ticks="outside",
+                showgrid=True,
+                fixedrange=True,
+                zeroline=False,
+                side="top",
+            ),
+            "yaxis": dict(
+                title="",
+                showticklabels=False,
+                autorange="reversed",
+                range=[-0.5, stacks + 0.5],
+                fixedrange=True,
+                tickmode="linear",
+                zeroline=False,
+            ),
+            "bargap": 0.01,
+        }
+    )
 
 
-def generate_outcome_string(query : QueryResult, hit : HitResult) -> str:
+def generate_outcome_string(query: QueryResult, hit: HitResult) -> str:
     """
     Takes a Query, and associated hit, and formats a human readable output string,
     handling associated construction logic.
@@ -236,7 +258,7 @@ def generate_outcome_string(query : QueryResult, hit : HitResult) -> str:
         if "regulated" in hit.annotations:
             return hit.annotations["regulated"][0]
         return ""
-    
+
     if "Benign" in hit.recommendation.from_step:
         return ""
 
@@ -259,56 +281,79 @@ def generate_outcome_string(query : QueryResult, hit : HitResult) -> str:
                 n_regulated_viruses += int(r["regulated_viruses"])
                 regulated_taxids.extend([x["species"] for x in r["regulated_taxa"]])
                 non_regulated_taxids.extend(r["non_regulated_taxa"])
-            
+
             for entry in set(regulated_taxids):
                 regulated_species.append(entry)
-            
+
             domain_string = " across multiple domains."
-            if n_regulated_bacteria > 0 and n_regulated_viruses == 0 and n_regulated_eukaryotes == 0:
+            if (
+                n_regulated_bacteria > 0
+                and n_regulated_viruses == 0
+                and n_regulated_eukaryotes == 0
+            ):
                 domain_string = " bacteria"
             elif n_regulated_eukaryotes > 0 and n_regulated_viruses == 0:
                 domain_string = " eukaryotes"
             elif n_regulated_viruses > 0:
                 domain_string = " viruses"
 
-            total_hits : int = len(regulated_taxids) + len(non_regulated_taxids)
-            peptide_type = "protein" if "Protein" in hit.recommendation.from_step else "nucleotides"
+            total_hits: int = len(regulated_taxids) + len(non_regulated_taxids)
+            peptide_type = (
+                "protein"
+                if "Protein" in hit.recommendation.from_step
+                else "nucleotides"
+            )
 
             if len(non_regulated_taxids) > 0:
-                output_string += "Mix of regulated and non-regulated" + domain_string + ".<br>"
+                output_string += (
+                    "Mix of regulated and non-regulated" + domain_string + ".<br>"
+                )
             else:
                 output_string += "Best match to regulated" + domain_string + ".<br>"
 
-            output_string += str(total_hits) + " Best match hits to " if total_hits > 1 else "Best hit to "
-            output_string += peptide_type + " found in " + str(len(regulated_species)) + " species, with regulated pathogen taxId in "
+            output_string += (
+                str(total_hits) + " Best match hits to "
+                if total_hits > 1
+                else "Best hit to "
+            )
+            output_string += (
+                peptide_type
+                + " found in "
+                + str(len(regulated_species))
+                + " species, with regulated pathogen taxId in "
+            )
             output_string += "lineage " if len(regulated_species) == 1 else "lineages "
 
-            species_list = textwrap.fill(
-                ", ".join(regulated_species), 100
-            ).replace("\n", "<br>")
-            
+            species_list = textwrap.fill(", ".join(regulated_species), 100).replace(
+                "\n", "<br>"
+            )
+
             output_string += "<br>" + species_list
 
             return output_string
-            #Best match to regulated viruses. 2 best match hits to nucleotides found in 1 species, 2 with regulated pathogen taxId in lineage (Influenza A)
+            # Best match to regulated viruses. 2 best match hits to nucleotides found in 1 species, 2 with regulated pathogen taxId in lineage (Influenza A)
         return "No Annotations."
 
-#@pytest.mark.filterwarnings("ignore")
-def draw_query_to_plot(fig : go.Figure, query_to_draw : QueryResult):
-    """ 
-    Write the data from a single query into the figure for plotly. 
+
+# @pytest.mark.filterwarnings("ignore")
+def draw_query_to_plot(fig: go.Figure, query_to_draw: QueryResult):
+    """
+    Write the data from a single query into the figure for plotly.
     """
     # Interpret the QueryResult into bars for the plot.
     graph_data = [
-        {"label": query_to_draw.query, 
-         "label_verbose": query_to_draw.query, 
-         "outcome" : f"Commec Recommendation for this query: {query_to_draw.status.screen_status}",
-         "outcome_verbose":f"{query_to_draw.status.rationale}",
-         "start": 1, "stop": query_to_draw.length,
-         "color" : CommecPalette.DK_BLUE, 
-         "stack" : 0,
-         "text" : query_to_draw.query[:25],
-         "text_color" : "#FFFFFF",}
+        {
+            "label": query_to_draw.query,
+            "label_verbose": query_to_draw.query,
+            "outcome": f"Commec Recommendation for this query: {query_to_draw.status.screen_status}",
+            "outcome_verbose": f"{query_to_draw.status.rationale}",
+            "start": 1,
+            "stop": query_to_draw.length,
+            "color": CommecPalette.DK_BLUE,
+            "stack": 0,
+            "text": query_to_draw.query[:25],
+            "text_color": "#FFFFFF",
+        }
     ]
 
     # Keep track of how many vertical stacks this image has.
@@ -318,31 +363,31 @@ def draw_query_to_plot(fig : go.Figure, query_to_draw : QueryResult):
         for match in hit.ranges:
             # Find the best vertical position to reduce collisions, and fill all space.
             collision_free = False
-            stack_write = 1 # 1 gives a bit of space between the query and the data.
+            stack_write = 1  # 1 gives a bit of space between the query and the data.
             while not collision_free:
                 stack_write += 1
                 collision_free = True
                 for entry in graph_data:
                     if entry["stack"] == stack_write:
-                        collision_free = (collision_free and
-                                            (match.query_start > entry["stop"] 
-                                            or match.query_end < entry["start"])
-                                            )
+                        collision_free = collision_free and (
+                            match.query_start > entry["stop"]
+                            or match.query_end < entry["start"]
+                        )
 
             n_stacks = max(n_stacks, stack_write + 1)
 
             graph_data.append(
                 {
-                    "label" : hit.description[:25] + "...",
-                    "label_verbose" : hit.description[:],
-                    "outcome" : f"{hit.recommendation.status} from {hit.recommendation.from_step}",
-                    "outcome_verbose" : generate_outcome_string(query_to_draw, hit),
-                    "start" : match.query_start,
-                    "stop" : match.query_end,
-                    "color" : color_from_hit(hit),
-                    "stack" : stack_write,
-                    "text" : overlay_text_from_hit(hit),
-                    "text_color" : constrast_color_from_hit(hit),
+                    "label": hit.description[:25] + "...",
+                    "label_verbose": hit.description[:],
+                    "outcome": f"{hit.recommendation.status} from {hit.recommendation.from_step}",
+                    "outcome_verbose": generate_outcome_string(query_to_draw, hit),
+                    "start": match.query_start,
+                    "stop": match.query_end,
+                    "color": color_from_hit(hit),
+                    "stack": stack_write,
+                    "text": overlay_text_from_hit(hit),
+                    "text_color": constrast_color_from_hit(hit),
                 }
             )
 
@@ -350,41 +395,50 @@ def draw_query_to_plot(fig : go.Figure, query_to_draw : QueryResult):
 
     # Convert RGB colors to hex format
     def rgb_to_hex(rgb):
-        return '#{:02x}{:02x}{:02x}'.format(rgb[0], rgb[1], rgb[2])
-    df['color'] = df['color'].apply(rgb_to_hex)
+        return "#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2])
 
+    df["color"] = df["color"].apply(rgb_to_hex)
 
-    df['hovertext'] = df.apply(lambda bar_data: 
-                               f"{bar_data["outcome"]}<br>"
-                               f"bases {bar_data['start']}-{bar_data['stop']}<br>"
-                               f"{bar_data['label_verbose']}<br>"
-                               f"{bar_data["outcome_verbose"]}", axis=1)
+    df["hovertext"] = df.apply(
+        lambda bar_data: (
+            f"{bar_data['outcome']}<br>"
+            f"bases {bar_data['start']}-{bar_data['stop']}<br>"
+            f"{bar_data['label_verbose']}<br>"
+            f"{bar_data['outcome_verbose']}"
+        ),
+        axis=1,
+    )
 
     # Add each bar to the existing figure
     for _i, bar_data in df.iterrows():
-
-        marker_dictionary = {"color" : bar_data["color"]}
+        marker_dictionary = {"color": bar_data["color"]}
         if "Cleared" in bar_data["outcome"]:
-            marker_dictionary["pattern"] = dict(shape="/")  # Options: "/", "\\", "x", "-", "|", ".", "+"
+            marker_dictionary["pattern"] = dict(
+                shape="/"
+            )  # Options: "/", "\\", "x", "-", "|", ".", "+"
 
         fig.add_trace(
             go.Bar(
-                x=[bar_data['stop'] - (bar_data['start'] - 1)],  # Width of bar as timedelta
-                y=[bar_data['stack']],  # Stack position
-                base=bar_data['start']-1,  # Starting point on x-axis
-                orientation='h',
+                x=[
+                    bar_data["stop"] - (bar_data["start"] - 1)
+                ],  # Width of bar as timedelta
+                y=[bar_data["stack"]],  # Stack position
+                base=bar_data["start"] - 1,  # Starting point on x-axis
+                orientation="h",
                 marker=marker_dictionary,
-                hovertext=bar_data['hovertext'],
-                hoverinfo='text',
-                #customdata=df['clicktext'],
-                name=bar_data['label'],
-                width = 1.0,
+                hovertext=bar_data["hovertext"],
+                hoverinfo="text",
+                # customdata=df['clicktext'],
+                name=bar_data["label"],
+                width=1.0,
             ),
         )
 
         # Compute x center for horizontal bar
-        bar_center_x = (bar_data['start']-1) + (bar_data['stop'] - (bar_data['start']-1)) / 2
-        bar_y = bar_data['stack']
+        bar_center_x = (bar_data["start"] - 1) + (
+            bar_data["stop"] - (bar_data["start"] - 1)
+        ) / 2
+        bar_y = bar_data["stack"]
 
         fig.add_annotation(
             x=bar_center_x,
@@ -392,20 +446,21 @@ def draw_query_to_plot(fig : go.Figure, query_to_draw : QueryResult):
             text=f"<b>{bar_data['text']}</b>",
             showarrow=False,
             font=dict(
-                color=bar_data['text_color'],
+                color=bar_data["text_color"],
                 size=13,
             ),
-            xanchor='center',
-            yanchor='middle',
-            align='center',
-            xref='x',
-            yref='y',
+            xanchor="center",
+            yanchor="middle",
+            align="center",
+            xref="x",
+            yref="y",
         )
 
     return n_stacks
 
-def generate_rounded_rect(x0,y0,x1,y1,rx,ry):
-    """ 
+
+def generate_rounded_rect(x0, y0, x1, y1, rx, ry):
+    """
     Creates an SVG path for a rounded rectangle given the following dimensions:
     xy0: Top Left Corner
     xy1: Bottom Right Corner.
@@ -415,37 +470,46 @@ def generate_rounded_rect(x0,y0,x1,y1,rx,ry):
     """
     # Create an SVG path for the rounded rectangle:
     path = (
-        f'M {x0 + rx},{y0} '
-        f'L {x1 - rx},{y0} '
-        f'Q {x1},{y0} {x1},{y0 + ry} '
-        f'L {x1},{y1 - ry} '
-        f'Q {x1},{y1} {x1 - rx},{y1} '
-        f'L {x0 + rx},{y1} '
-        f'Q {x0},{y1} {x0},{y1 - ry} '
-        f'L {x0},{y0 + ry} '
-        f'Q {x0},{y0} {x0 + rx},{y0}'
-        f'Z'
+        f"M {x0 + rx},{y0} "
+        f"L {x1 - rx},{y0} "
+        f"Q {x1},{y0} {x1},{y0 + ry} "
+        f"L {x1},{y1 - ry} "
+        f"Q {x1},{y1} {x1 - rx},{y1} "
+        f"L {x0 + rx},{y1} "
+        f"Q {x0},{y1} {x0},{y1 - ry} "
+        f"L {x0},{y0 + ry} "
+        f"Q {x0},{y0} {x0 + rx},{y0}"
+        f"Z"
     )
     return path
 
-def generate_html_from_screen_json(input_file : str, output_file : str):
-    """ 
+
+def generate_html_from_screen_json(input_file: str, output_file: str):
+    """
     Wrapper for input filepath, rather than screen data object.
     """
-    input_data : ScreenResult = get_screen_data_from_json(input_file)
+    input_data: ScreenResult = get_screen_data_from_json(input_file)
     generate_html_from_screen_data(input_data, output_file)
 
+
 def main():
-    '''
+    """
     Convert a JSON output from Commec Screen, into a HTML data visualisation.
-    '''
+    """
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i","--input", dest="in_file",
-        required=True, help="Input json file path")
-    parser.add_argument("-o","--output", dest="out_file",
-        required=True, help="Output html filepath, not including .html extension.")
+    parser.add_argument(
+        "-i", "--input", dest="in_file", required=True, help="Input json file path"
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="out_file",
+        required=True,
+        help="Output html filepath, not including .html extension.",
+    )
     args = parser.parse_args()
     generate_html_from_screen_json(args.in_file, args.out_file)
+
 
 if __name__ == "__main__":
     main()

--- a/commec/utils/logger.py
+++ b/commec/utils/logger.py
@@ -8,13 +8,16 @@ import logging
 import sys
 import textwrap
 
+
 class TextWrapFormatter(logging.Formatter):
     """
-    Format multi-line log messages with proper vertical alignment, 
+    Format multi-line log messages with proper vertical alignment,
     configurable styling, and text wrapping for longer messages.
     """
 
-    def __init__(self, *args, fmt=None, continuation_marker="│ ", line_width=120, **kwargs):
+    def __init__(
+        self, *args, fmt=None, continuation_marker="│ ", line_width=120, **kwargs
+    ):
         if fmt is None:
             fmt = f"%(levelname)-8s{continuation_marker}%(message)s"
         super().__init__(fmt, *args, **kwargs)
@@ -50,10 +53,10 @@ class TextWrapFormatter(logging.Formatter):
 
         - **no_wrap**:
         Skips text wrapping.
-        
+
         - **no_prefix**:
         Skips the `INFO    │ ` prefixes.
-        
+
         - **box**, **box_up**, **box_down**:
         Use Unicode box-drawing characters (e.g., `"─┘"` or `"─┐"`) to tie off
         formatted prefixes when switching to no-prefix lines.
@@ -70,7 +73,7 @@ class TextWrapFormatter(logging.Formatter):
             prefix = self.indent_size * "─" + "┘\n" if box_up else ""
             suffix = "\n" + self.indent_size * "─" + "┐" if box_down else ""
 
-            return prefix + record.getMessage() + suffix # No formatting
+            return prefix + record.getMessage() + suffix  # No formatting
 
         message = super().format(record)
 
@@ -134,7 +137,7 @@ def setup_file_logging(filename, log_level=logging.INFO, log_mode="w"):
         formatter = TextWrapFormatter(
             fmt="%(asctime)s│ %(levelname)-8s│ %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",  # Full ISO-like format
-            line_width = 300, # Longer lines for debug purposes.
+            line_width=300,  # Longer lines for debug purposes.
         )
     else:
         formatter = TextWrapFormatter("%(levelname)-8s│ %(message)s")

--- a/conftest.py
+++ b/conftest.py
@@ -8,3 +8,11 @@ def pytest_addoption(parser):
         "--gen-examples", action="store_true", default=False,
         help="Generate exemplar output files instead of testing against them."
     )
+    parser.addoption(
+        "--commec-db-dir", action="store", default=None,
+        help=(
+            "Path to a real commec reference database directory. Required for the"
+            " end-to-end detection tests in test_evaluation.py; those tests are skipped"
+            " when it is not provided. May also be set via the COMMEC_DB_DIR env var."
+        )
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -1,18 +1,24 @@
 """
 Additional Configurations for Pytest
 """
+
+
 def pytest_addoption(parser):
-    """ Adds unique argument to pytest for commec database example outputs generation."""
+    """Adds unique argument to pytest for commec database example outputs generation."""
     print("Test Configuration loaded!")
     parser.addoption(
-        "--gen-examples", action="store_true", default=False,
-        help="Generate exemplar output files instead of testing against them."
+        "--gen-examples",
+        action="store_true",
+        default=False,
+        help="Generate exemplar output files instead of testing against them.",
     )
     parser.addoption(
-        "--commec-db-dir", action="store", default=None,
+        "--commec-db-dir",
+        action="store",
+        default=None,
         help=(
             "Path to a real commec reference database directory. Required for the"
             " end-to-end detection tests in test_evaluation.py; those tests are skipped"
             " when it is not provided. May also be set via the COMMEC_DB_DIR env var."
-        )
+        ),
     )

--- a/dev_scripts/collate-screens.py
+++ b/dev_scripts/collate-screens.py
@@ -13,6 +13,7 @@ Required inputs:
 Example:
 $ python collate-screens.py -i . -o ./test-collate-pls -f ../functional-json-test/
 """
+
 import argparse
 import csv
 import os
@@ -20,56 +21,60 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+
 def clean_header(header: str) -> str:
     """
     Clean a FASTA header by replacing whitespace and special characters with underscores.
-    
+
     Args:
         header: Original FASTA header
-        
+
     Returns:
         Cleaned header string
     """
     return "".join(
-        "_" if c.isspace() or c == "\xc2\xa0" or c == "#" else c
-        for c in header
+        "_" if c.isspace() or c == "\xc2\xa0" or c == "#" else c for c in header
     )
+
 
 def parse_fasta_header(fasta_path: Path) -> Tuple[str, str]:
     """
     Extract filename and cleaned FASTA header from a FASTA file.
-    
+
     Args:
         fasta_path: Path to the FASTA file
-        
+
     Returns:
         Tuple of (filename, cleaned_header)
     """
     filename = fasta_path.name
     with open(fasta_path) as f:
         for line in f:
-            if line.startswith('>'):
+            if line.startswith(">"):
                 header = line.strip()
                 cleaned_header = clean_header(header)
                 return filename, cleaned_header
     raise ValueError(f"No valid FASTA header found in {fasta_path}")
 
+
 def build_fasta_mapping(fasta_dir: Path) -> Dict[str, str]:
     """
     Build mapping of FASTA headers to filenames from all FASTA files in directory.
-    
+
     Args:
         fasta_dir: Directory containing FASTA files
-        
+
     Returns:
         Dictionary mapping FASTA headers to original filenames
     """
     mapping = {}
     for root, _, files in os.walk(fasta_dir):
         for file in files:
-            if (file.endswith('.fasta') and 
-                not file.endswith('.noncoding.fasta') and 
-                not file.endswith('.cleaned.fasta')):
+            if (
+                file.endswith(".fasta")
+                and not file.endswith(".noncoding.fasta")
+                and not file.endswith(".cleaned.fasta")
+            ):
                 fasta_path = Path(root) / file
                 try:
                     filename, cleaned_header = parse_fasta_header(fasta_path)
@@ -78,6 +83,7 @@ def build_fasta_mapping(fasta_dir: Path) -> Dict[str, str]:
                     print(f"Warning: Could not process {fasta_path}: {e}")
     return mapping
 
+
 def find_screen_files(input_dir: Path) -> List[Path]:
     """
     Find all .screen files in the input directory.
@@ -85,9 +91,10 @@ def find_screen_files(input_dir: Path) -> List[Path]:
     screen_files = []
     for root, _, files in os.walk(input_dir):
         for file in files:
-            if file.endswith('.screen'):
+            if file.endswith(".screen"):
                 screen_files.append(Path(root) / file)
     return screen_files
+
 
 def get_matching_fasta_header(screen_path: Path) -> str:
     """
@@ -95,38 +102,60 @@ def get_matching_fasta_header(screen_path: Path) -> str:
     """
     # For a file named "something.screen", look for "input_something/something.cleaned.fasta"
     screen_name = screen_path.stem  # removes .screen extension
-    fasta_path = screen_path.parent / f"input_{screen_name}" / f"{screen_name}.cleaned.fasta"
+    fasta_path = (
+        screen_path.parent / f"input_{screen_name}" / f"{screen_name}.cleaned.fasta"
+    )
     if not fasta_path.exists():
         raise FileNotFoundError(f"Expected FASTA not found at {fasta_path}")
-    
+
     with open(fasta_path) as f:
         for line in f:
-            if line.startswith('>'):
+            if line.startswith(">"):
                 header = line.strip()
                 return clean_header(header)
     raise ValueError(f"No valid FASTA header found in {fasta_path}")
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Collate and rename screen files based on FASTA headers')
-    parser.add_argument('-i', '--input-dir', required=True, help='Input directory containing screen files')
-    parser.add_argument('-o', '--output-dir', required=True, help='Output directory for renamed screen files')
-    parser.add_argument('-f', '--fasta-dir', required=True, help='Directory containing original FASTA files')
-    
+    parser = argparse.ArgumentParser(
+        description="Collate and rename screen files based on FASTA headers"
+    )
+    parser.add_argument(
+        "-i",
+        "--input-dir",
+        required=True,
+        help="Input directory containing screen files",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        required=True,
+        help="Output directory for renamed screen files",
+    )
+    parser.add_argument(
+        "-f",
+        "--fasta-dir",
+        required=True,
+        help="Directory containing original FASTA files",
+    )
+
     args = parser.parse_args()
-    
+
     input_dir = Path(args.input_dir).resolve()
     output_dir = Path(args.output_dir).resolve()
     fasta_dir = Path(args.fasta_dir).resolve()
-    
+
     # Create output directory if it doesn't exist
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Build mapping of FASTA headers to original filenames
     print(f"Building FASTA header mapping based on files found in {fasta_dir}...")
     header_to_filename = build_fasta_mapping(fasta_dir)
     num_fastas_mapped = len(header_to_filename)
     if num_fastas_mapped == 0:
-        print("Could not find any FASTAs to map! Note that .cleaned and .noncoding are filtered out.\nExiting...")
+        print(
+            "Could not find any FASTAs to map! Note that .cleaned and .noncoding are filtered out.\nExiting..."
+        )
         exit(0)
     print(f"Found {num_fastas_mapped} FASTAS for mapping...")
 
@@ -140,40 +169,45 @@ def main():
         try:
             # Get the FASTA header for this screen file
             fasta_header = get_matching_fasta_header(screen_path)
-            
+
             # Look up the matching filename
             if fasta_header not in header_to_filename:
                 print(f"Warning: No matching FASTA file found for {screen_path}")
                 continue
-                
+
             matching_filename = header_to_filename[fasta_header]
             new_filename = f"{Path(matching_filename).stem}.screen"
             output_path = output_dir / new_filename
-            
+
             # Copy the screen file with the new name
             shutil.copy2(screen_path, output_path)
-            
+
             # Record the mapping
-            mappings.append({
-                'screen': str(screen_path),
-                'matched_fasta': matching_filename,
-                'renamed_screen': new_filename
-            })
-            
+            mappings.append(
+                {
+                    "screen": str(screen_path),
+                    "matched_fasta": matching_filename,
+                    "renamed_screen": new_filename,
+                }
+            )
+
             print(f"Processed: {screen_path} -> {output_path}")
-            
+
         except (FileNotFoundError, ValueError, IOError) as e:
             print(f"Error processing {screen_path}: {e}")
-    
+
     # Write mapping CSV
-    csv_path = output_dir / 'screen_mappings.csv'
-    with open(csv_path, 'w', newline='') as f:
-        writer = csv.DictWriter(f, fieldnames=['screen', 'matched_fasta', 'renamed_screen'])
+    csv_path = output_dir / "screen_mappings.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["screen", "matched_fasta", "renamed_screen"]
+        )
         writer.writeheader()
         writer.writerows(mappings)
-    
+
     print(f"\nProcessed {len(mappings)} screen files")
     print(f"Mapping saved to {csv_path}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/dev_scripts/flag-legacy.py
+++ b/dev_scripts/flag-legacy.py
@@ -21,12 +21,17 @@ import glob
 import os
 import re
 from enum import StrEnum
+
 import pandas as pd
-from commec.utils.file_utils import directory_arg
+
 from commec.config.result import ScreenStatus
 from commec.flag import read_flags_from_json
+from commec.utils.file_utils import directory_arg
 
-DESCRIPTION = "Parse all .screen, or .json files in a directory and create CSVs of flags raised"
+DESCRIPTION = (
+    "Parse all .screen, or .json files in a directory and create CSVs of flags raised"
+)
+
 
 class Outcome(StrEnum):
     """Possible outcomes for each step of the screening process."""
@@ -35,7 +40,9 @@ class Outcome(StrEnum):
     PASS = "pass"  # the sequence passed in this step
     SKIP = "skip"  # step was intentionally not run
     ERROR = "error"  # an error occurred during this step
-    NOT_RUN = "-"  # step was not run due to an error, interrupt, or other unexpected outcome
+    NOT_RUN = (
+        "-"  # step was not run due to an error, interrupt, or other unexpected outcome
+    )
     # (protein / nucloetide only) equally-good best match to regulated and non-regulated organisms
     MIX = "mix"
     # (biorisk only) significant hit to a virulence factor, but these are often shared between
@@ -80,6 +87,7 @@ def add_args(parser: argparse.ArgumentParser):
     )
     return parser
 
+
 def read_flags_from_screen(file_path) -> dict[str, str | set[str] | bool]:
     """
     Read log .screen output and prepare screen_pipline_status CSV.
@@ -90,7 +98,7 @@ def read_flags_from_screen(file_path) -> dict[str, str | set[str] | bool]:
     filename_without_extension = os.path.splitext(os.path.basename(file_path))[0]
 
     steps = []
-    
+
     # Don't capture any of the file before STEP 1
     first_step = re.search(r">> STEP 1:", content)
     # Split by STEP
@@ -111,7 +119,7 @@ def read_flags_from_screen(file_path) -> dict[str, str | set[str] | bool]:
         "low_concern": get_low_concern_outcome(steps[3]),
     }
 
-    # Add regulated flags - only check protein, since nucleotide may 
+    # Add regulated flags - only check protein, since nucleotide may
     # have been skipped due to having no noconding regions.
     if step_ran_successfully(results["protein"]):
         results.update(get_regulated_taxa(content))
@@ -136,8 +144,9 @@ def process_file(file_path) -> dict[str, str | set[str] | bool]:
         return read_flags_from_json(file_path)
     if extension == ".screen":
         return read_flags_from_screen(file_path)
-    raise ValueError("Error: unrecognised file extension"
-                     f"(not .screen, or .json): {extension}")
+    raise ValueError(
+        f"Error: unrecognised file extension(not .screen, or .json): {extension}"
+    )
 
 
 def get_biorisk_outcome(step_content: str) -> set[str]:
@@ -203,7 +212,10 @@ def get_low_concern_outcome(step_content) -> set[str]:
     if "no regulated regions to clear" in step_content:
         outcomes.add(Outcome.SKIP)
 
-    if "Regulated region at bases" in step_content and "failed to clear: FLAG" in step_content:
+    if (
+        "Regulated region at bases" in step_content
+        and "failed to clear: FLAG" in step_content
+    ):
         outcomes.add(Outcome.NOT_CLEARED)
     if "all regulated regions cleared: PASS" in step_content:
         outcomes.add(Outcome.CLEARED)
@@ -229,9 +241,15 @@ def get_low_concern_substeps(step_content) -> dict[str, bool]:
     Check for whether low_concern protiein, RNA or DNA (synbio sequences) is in the content.
     """
     return {
-        "low_concern_protein": True if re.search(r"-->.*?protein.*?PASS", step_content) else False,
-        "low_concern_rna": True if re.search(r"-->.*?RNA.*?PASS", step_content) else False,
-        "low_concern_dna": True if re.search(r"-->.*?Synbio sequence.*?PASS", step_content) else False,
+        "low_concern_protein": True
+        if re.search(r"-->.*?protein.*?PASS", step_content)
+        else False,
+        "low_concern_rna": True
+        if re.search(r"-->.*?RNA.*?PASS", step_content)
+        else False,
+        "low_concern_dna": True
+        if re.search(r"-->.*?Synbio sequence.*?PASS", step_content)
+        else False,
     }
 
 
@@ -292,7 +310,9 @@ def get_flags_from_status(results: dict[str, str | set[str] | bool]) -> dict[str
     # Set biorisk and virtulence factor flags based on biorisk search
     if step_ran_successfully(results["biorisk"]):
         biorisk = Flag.FLAG if Outcome.FLAG in results["biorisk"] else Flag.PASS
-        virulence_factor = Flag.FLAG if Outcome.WARN in results["biorisk"] else Flag.PASS
+        virulence_factor = (
+            Flag.FLAG if Outcome.WARN in results["biorisk"] else Flag.PASS
+        )
 
     # Error overrides anything else
     if Outcome.ERROR in results["biorisk"]:
@@ -305,15 +325,18 @@ def get_flags_from_status(results: dict[str, str | set[str] | bool]) -> dict[str
         regulated_eukaryote = Flag.FLAG if results["eukaryote_flag"] else Flag.PASS
         mixed_regulated_non_reg = (
             Flag.FLAG
-            if (Outcome.MIX in results["protein"] or Outcome.MIX in results["nucleotide"])
+            if (
+                Outcome.MIX in results["protein"]
+                or Outcome.MIX in results["nucleotide"]
+            )
             else Flag.PASS
         )
 
     # Error overrides anything else
     if Outcome.ERROR in results["protein"] or Outcome.ERROR in results["nucleotide"]:
-        regulated_virus = regulated_bacteria = regulated_eukaryote = mixed_regulated_non_reg = (
-            Flag.ERROR
-        )
+        regulated_virus = regulated_bacteria = regulated_eukaryote = (
+            mixed_regulated_non_reg
+        ) = Flag.ERROR
 
     # Set low_concern flag based on low_concern search
     if Outcome.CLEARED in results["low_concern"]:
@@ -342,6 +365,7 @@ def get_flags_from_status(results: dict[str, str | set[str] | bool]) -> dict[str
         "low_concern": low_concern,
     }
 
+
 def status_to_outcome(result: ScreenStatus) -> Outcome:
     """
     Map between a ScreenStatus result from json, and the outcome.
@@ -357,6 +381,7 @@ def status_to_outcome(result: ScreenStatus) -> Outcome:
         ScreenStatus.NULL: Outcome.NOT_RUN,
     }
     return mapping.get(result, Outcome.ERROR)
+
 
 def get_recommendation(flag: str) -> str:
     """
@@ -381,18 +406,24 @@ def write_output_csvs(output_dir, status, flags, recommendations):
     recommendations_file = os.path.join(output_dir, "flags_recommended.csv")
 
     status_df = pd.DataFrame(status)
-    status_df = status_df.map(lambda x: ";".join(sorted(x)) if isinstance(x, set) else x)
+    status_df = status_df.map(
+        lambda x: ";".join(sorted(x)) if isinstance(x, set) else x
+    )
     status_df.to_csv(status_file, index=False)
     print(f"Pipeline step status written to {status_file}")
 
     pd.DataFrame(flags).to_csv(flags_file, index=False)
     print(f"Screen results written to {flags_file}")
 
-    summary = pd.DataFrame(recommendations, columns=["filename", "recommend_flag_or_pass"])
+    summary = pd.DataFrame(
+        recommendations, columns=["filename", "recommend_flag_or_pass"]
+    )
     summary.to_csv(recommendations_file, index=False, header=None)
     print(f"Flag recommendations written to {recommendations_file}")
 
-    print("Flags: ", (summary["recommend_flag_or_pass"] == "F").sum(), "/", len(summary))
+    print(
+        "Flags: ", (summary["recommend_flag_or_pass"] == "F").sum(), "/", len(summary)
+    )
     print("Errors: ", (summary["recommend_flag_or_pass"] == "Err").sum())
 
 
@@ -409,16 +440,22 @@ def run(args: argparse.Namespace):
     output_dir = args.output or os.path.dirname(search_dir)
 
     search_pattern = "**/*.json" if search_recursive else "*.json"
-    screen_paths_json = glob.glob(os.path.join(search_dir, search_pattern), recursive=search_recursive)
+    screen_paths_json = glob.glob(
+        os.path.join(search_dir, search_pattern), recursive=search_recursive
+    )
 
     search_pattern = "**/*.screen" if search_recursive else "*.screen"
-    screen_paths_screen = glob.glob(os.path.join(search_dir, search_pattern), recursive=search_recursive)
-    
-    #screen_paths_json.extend(screen_paths_screen)
+    screen_paths_screen = glob.glob(
+        os.path.join(search_dir, search_pattern), recursive=search_recursive
+    )
+
+    # screen_paths_json.extend(screen_paths_screen)
     screen_paths = screen_paths_screen + screen_paths_json
 
     if not screen_paths:
-        raise FileNotFoundError(f"No .screen files were found in directory: {search_dir}")
+        raise FileNotFoundError(
+            f"No .screen files were found in directory: {search_dir}"
+        )
 
     screen_status = []
     for file_path in sorted(screen_paths):
@@ -430,7 +467,8 @@ def run(args: argparse.Namespace):
 
     screen_flags = [get_flags_from_status(status) for status in screen_status]
     recommendations = [
-        (status["filepath"], get_recommendation(status["flag"])) for status in screen_status
+        (status["filepath"], get_recommendation(status["flag"]))
+        for status in screen_status
     ]
 
     write_output_csvs(output_dir, screen_status, screen_flags, recommendations)

--- a/dev_scripts/split_fasta.py
+++ b/dev_scripts/split_fasta.py
@@ -7,42 +7,55 @@ input.#.fa.
 Command-line usage:
     split_fasta.py --i input_fasta -n num_seqs
 """
-import os, sys, argparse
-from Bio import SeqIO 
+
+import argparse
+import os
+import sys
+
+from Bio import SeqIO
+
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i","--input", dest="i_file",
-        required=True, help="multi-FASTA file to split") 
-    parser.add_argument("-n","--num", dest="num_seqs",
+    parser.add_argument(
+        "-i", "--input", dest="i_file", required=True, help="multi-FASTA file to split"
+    )
+    parser.add_argument(
+        "-n",
+        "--num",
+        dest="num_seqs",
         type=int,
-        required=True, help="Number of sequences per file (min)") 
-    args = parser.parse_args() 
-    
+        required=True,
+        help="Number of sequences per file (min)",
+    )
+    args = parser.parse_args()
+
     basename = os.path.splitext(args.i_file)[0]
     basename = os.path.basename(basename)
     count_curr = 0
-    count_total = 0 
+    count_total = 0
     num_splits = 0
-    sys.stdout.write("\t%i sequences printed (%i splits)" % (count_total,num_splits))
+    sys.stdout.write("\t%i sequences printed (%i splits)" % (count_total, num_splits))
     sys.stdout.flush()
-    for record in SeqIO.parse(args.i_file,"fasta"):
+    for record in SeqIO.parse(args.i_file, "fasta"):
         if count_curr == 0:
             num_splits += 1
-            o_file = open(basename + "." + str(num_splits) + ".fa" , 'w')
+            o_file = open(basename + "." + str(num_splits) + ".fa", "w")
         SeqIO.write(record, o_file, "fasta")
-        count_curr += 1 
+        count_curr += 1
         count_total += 1
         if count_total % 10000 == 0:
-            sys.stdout.write("\r\t%i sequences printed (%i splits)" % (count_total,num_splits))
+            sys.stdout.write(
+                "\r\t%i sequences printed (%i splits)" % (count_total, num_splits)
+            )
             sys.stdout.flush()
         if count_curr == args.num_seqs:
-            count_curr = 0 
+            count_curr = 0
             o_file.close()
-    
-    sys.stdout.write("\t%i sequences printed (%i splits)\n" % (count_total,num_splits))
+
+    sys.stdout.write("\t%i sequences printed (%i splits)\n" % (count_total, num_splits))
     sys.stdout.flush()
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/dev_scripts/summarize_screens.py
+++ b/dev_scripts/summarize_screens.py
@@ -20,9 +20,10 @@ Each line in the CSV corresponds to a .screen file. The full paths to the files 
 Additionally, it includes three columns indicating whether the sequence was flagged as a regulated
 virus, bacteria, or eukaryote.
 """
-import os
-import csv
+
 import argparse
+import csv
+import os
 import re
 
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,5 +24,6 @@ dependencies:
   - pip
   - pytest
   - matplotlib
+  - ruff
   - pip:
       - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,9 @@ Repository = "https://github.com/ibbis-screening/common-mechanism.git"
 [tool.setuptools]
 packages = { find = { "include" = ["commec", "commec.*"] } }
 package-data = { "commec" = ["utils/template.html", "screen-default-config.yaml"] }
+
+[tool.ruff]
+exclude = ["commec/tests/**/*.py", "dev_scripts/**/*.py"]
+
+[tool.ruff.lint]
+ignore = ["E712"]


### PR DESCRIPTION
## Background
<!--
Leave a gift for your future self about what this PR was.

Please include relevant motivation and context for this PR.

List any dependencies that are required for this change.
-->
This is one of the steps to improve the generic cyber stance of commec, and has the side effects of ensuring that it's easier to maintain and understand the code.

Essentially, I installed [ruff](https://docs.astral.sh/ruff) and ran `ruff check --fix`, `ruff check --select I --fix`, and `ruff format`. These three commands find and fix common errors, ensure a consistent format and order for imports, and format the code.

I also commented out a line in [json_html_output.py](commec/utils/json_html_output.py) to remove a dead code finding from `ruff check`.

There are 2 follow-on steps from this:

1. Add ruff to CI. GitHub Actions doesn't reallllyyyy lend itself well to using ruff, but I can add it to a new workflow that's "linting" or something.
2. Run [ty](https://docs.astral.sh/ty) on this codebase. Essentially, that will be type checking, and will likely result in more impactful changes.

Also note that this will improve collaboration, since this sets the standard for what code should look like, and will prevent some common formatting issues in PRs.

<!--
Does this relate to any open issues? Please include them, or delete the line below.
-->
**Issues**:
<!--
Having the text: "#1234" would connect the current pull request to issue 1234.

You can use the Github keywords [fix/es, resolve/s], but this will automatically
close the issue, so only do so if the PR fully resolves them!
-->

## Changes
### Refactoring
* Ran `ruff format`, `ruff check --select I --fix`, and `ruff check --fix`
* Commented out `r, g, b` line in `update_layout` since it was not used (found by ruff)
* Added ruff configuration to silence some errors, ensure that only relevant code was checked (note - I ran `ruff format` before adding this configuration, so dev_scripts/ and tests/ were both changed - I can revert if preferred).
