### PR TITLE
Switched blast mode to 0

### DIFF
--- a/commec/config/screen_tools.py
+++ b/commec/config/screen_tools.py
@@ -59,6 +59,7 @@ class ScreenTools:
                     input_file=params.nt_path,
                     out_file=f"{params.output_prefix}.nr.blastx",
                     threads=params.config["threads"],
+                    mt_mode=params.config["mt_mode"],
                     force=params.config["force"],
                 )
             elif params.config["protein_search_tool"] in ("nr.dmnd", "diamond"):
@@ -84,6 +85,7 @@ class ScreenTools:
                 input_file=params.nc_path,
                 out_file=f"{params.output_prefix}.nt.blastn",
                 threads=params.config["threads"],
+                mt_mode=params.config["mt_mode"],
                 force=params.config["force"],
             )
 
@@ -100,6 +102,7 @@ class ScreenTools:
                 input_file=params.nt_path,
                 out_file=f"{params.output_prefix}.low_concern.blastn",
                 threads=params.config["threads"],
+                mt_mode=params.config["mt_mode"],
                 force=params.config["force"],
             )
             self.low_concern_cmscan = CmscanHandler(

--- a/commec/screen-default-config.yaml
+++ b/commec/screen-default-config.yaml
@@ -24,6 +24,7 @@ databases:
   taxonomy:
       path: "{default}taxonomy/"
 threads: 1
+mt_mode: 1
 diamond_jobs: null
 do_cleanup: False
 force: False

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -199,6 +199,13 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         type=int,
         help="Diamond-only: number of runs to do in parallel on split Diamond databases",
     )
+    parallel_group.add_argument(
+        "--mt-mode",
+        dest="mt_mode",
+        type=int,
+        choices=[0, 1, 2],
+        help="BLAST multithreading mode for blastx/blastn: see NCBI documentation.",
+    )
     output_handling_group = parser.add_argument_group("Output file handling")
     output_exclusive_group = output_handling_group.add_mutually_exclusive_group()
     output_handling_group.add_argument(

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -42,6 +42,7 @@ def expected_defaults():
             }
         },
         "threads": 1,
+        "mt_mode": 1,
         "protein_search_tool": "blastx",
         "skip_taxonomy_search": False,
         "skip_nt_search": False,
@@ -96,6 +97,7 @@ def expected_updated_from_custom_yaml():
             }
         },
         "threads": 8,
+        "mt_mode": 1,
         "protein_search_tool": "blastx",
         "skip_taxonomy_search": True,
         "skip_nt_search": False,

--- a/commec/tools/blastn.py
+++ b/commec/tools/blastn.py
@@ -29,7 +29,7 @@ class BlastNHandler(BlastHandler):
             "-template_type": "optimal",
             "-template_length": 16,
             "-num_threads": self.threads,
-            "-mt_mode": 1,
+            "-mt_mode": 0,
             "-evalue": 1e-5,
             "-max_target_seqs": 500,
             "-culling_limit": 1,

--- a/commec/tools/blastn.py
+++ b/commec/tools/blastn.py
@@ -29,7 +29,7 @@ class BlastNHandler(BlastHandler):
             "-template_type": "optimal",
             "-template_length": 16,
             "-num_threads": self.threads,
-            "-mt_mode": 0,
+            "-mt_mode": kwargs.get("mt_mode", 1),
             "-evalue": 1e-5,
             "-max_target_seqs": 500,
             "-culling_limit": 1,

--- a/commec/tools/blastx.py
+++ b/commec/tools/blastx.py
@@ -27,7 +27,7 @@ class BlastXHandler(BlastHandler):
         self.arguments_dictionary = {
             "-task": "blastx-fast",
             "-num_threads": self.threads,
-            "-mt_mode": 1,
+            "-mt_mode": 0,
             "-evalue": 1e-10,
             "-max_target_seqs": 500,
             "-culling_limit": 1,

--- a/commec/tools/blastx.py
+++ b/commec/tools/blastx.py
@@ -27,7 +27,7 @@ class BlastXHandler(BlastHandler):
         self.arguments_dictionary = {
             "-task": "blastx-fast",
             "-num_threads": self.threads,
-            "-mt_mode": 0,
+            "-mt_mode": kwargs.get("mt_mode", 1),
             "-evalue": 1e-10,
             "-max_target_seqs": 500,
             "-culling_limit": 1,


### PR DESCRIPTION
Letting blast pick how it wants to use its cores seems to increase utilization & performance for both large and small queries (tested on 12 threads).

https://www.ncbi.nlm.nih.gov/books/NBK571452/

| query | seqs | mt_mode | total (s) | blastx nr (s) | blastx cores | blastn nt (s) | blastn cores |
|---|---:|---:|---:|---:|---:|---:|---:|
| builtin | 5 | 0 | 499 | 254 | 11.4 | 239 | 10.8 |
| builtin | 5 | 1 | 2667 | 1496 | 2.1 | 1164 | 2.1 |
| bronze | 876 | 0 | 5151 | 4232 | 11.9 | 502 | 11.5 |
| bronze | 876 | 1 | 9513 | 6172 | 10.3 | 2923 | 2.0 |