### PR TITLE
+allow mt mode to be changed from yml

### DIFF
--- a/commec/config/constants.py
+++ b/commec/config/constants.py
@@ -17,6 +17,9 @@ BIORISK_LONG_QUERY_EVALUE_THRESHOLD = 1e-20
 HMMSCAN_MAX_THREAD_LIMIT = 4
 CMSCAN_MAX_THREAD_LIMIT = 4
 
+# Valid values for the BLAST -mt_mode argument (0: auto, 1: split by database, 2: split by query)
+VALID_BLAST_MT_MODES = (0, 1, 2)
+
 # I/O
 DEFAULT_CONFIG_YAML_PATH = "screen-default-config.yaml"
 MAXIMUM_FILENAME_SIZE = 255

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -27,6 +27,7 @@ from commec.config.constants import (
     MAXIMUM_QUERY_LENGTH,
     MAXIMUM_FILENAME_SIZE,
     MAXIMUM_QUERY_NAME_LENGTH,
+    VALID_BLAST_MT_MODES,
 )
 from commec.utils.file_utils import expand_and_normalize
 from commec.utils.dict_utils import deep_update
@@ -85,6 +86,12 @@ class ScreenIO:
 
         if self.config["threads"] < 1:
             raise RuntimeError("Number of allocated threads must be at least 1!")
+
+        if self.config["blast_mt_mode"] not in VALID_BLAST_MT_MODES:
+            raise RuntimeError(
+                f"blast_mt_mode must be one of {VALID_BLAST_MT_MODES}, "
+                f"but got {self.config['blast_mt_mode']!r}"
+            )
 
         if (
             self.config["diamond_jobs"] is not None

--- a/commec/config/screen_tools.py
+++ b/commec/config/screen_tools.py
@@ -61,6 +61,7 @@ class ScreenTools:
                     threads=params.config["threads"],
                     force=params.config["force"],
                 )
+                self.regulated_protein.arguments_dictionary["-mt_mode"] = params.config["blast_mt_mode"]
             elif params.config["protein_search_tool"] in ("nr.dmnd", "diamond"):
                 self.regulated_protein = DiamondHandler(
                     params.config["databases"]["regulated_protein"]["diamond"]["path"],
@@ -86,6 +87,7 @@ class ScreenTools:
                 threads=params.config["threads"],
                 force=params.config["force"],
             )
+            self.regulated_nt.arguments_dictionary["-mt_mode"] = params.config["blast_mt_mode"]
 
         if params.should_do_low_concern_screening:
             self.low_concern_hmm = HmmerHandler(
@@ -102,6 +104,7 @@ class ScreenTools:
                 threads=params.config["threads"],
                 force=params.config["force"],
             )
+            self.low_concern_blastn.arguments_dictionary["-mt_mode"] = params.config["blast_mt_mode"]
             self.low_concern_cmscan = CmscanHandler(
                 params.config["databases"]["low_concern"]["rna"]["path"],
                 input_file=params.nt_path,

--- a/commec/screen-default-config.yaml
+++ b/commec/screen-default-config.yaml
@@ -25,9 +25,6 @@ databases:
       path: "{default}taxonomy/"
 threads: 1
 diamond_jobs: null
-# Multithreading mode passed to blastn/blastx as -mt_mode (0, 1, or 2; 0 = auto).
-# On fast local disk, 0 performs well across query sizes; for slow networked
-# storage (e.g. HPC/NFS) 1 tends to be faster. Default 1 preserves prior behaviour.
 blast_mt_mode: 1
 do_cleanup: False
 force: False

--- a/commec/screen-default-config.yaml
+++ b/commec/screen-default-config.yaml
@@ -25,6 +25,10 @@ databases:
       path: "{default}taxonomy/"
 threads: 1
 diamond_jobs: null
+# Multithreading mode passed to blastn/blastx as -mt_mode (0, 1, or 2; 0 = auto).
+# On fast local disk, 0 performs well across query sizes; for slow networked
+# storage (e.g. HPC/NFS) 1 tends to be faster. Default 1 preserves prior behaviour.
+blast_mt_mode: 1
 do_cleanup: False
 force: False
 skip_taxonomy_search: False

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -47,6 +47,7 @@ def expected_defaults():
         "skip_nt_search": False,
         "do_cleanup": False,
         "diamond_jobs": None,
+        "blast_mt_mode": 1,
         "force": False,
         "resume": False,
         "verbose": False
@@ -101,6 +102,7 @@ def expected_updated_from_custom_yaml():
         "skip_nt_search": False,
         "do_cleanup": False,
         "diamond_jobs": None,
+        "blast_mt_mode": 1,
         "force": True,
         "resume": False,
         "verbose": False
@@ -181,6 +183,20 @@ def test_cli_override(tmp_path, expected_updated_from_custom_yaml, custom_yaml_c
     )
 
     assert expected_defaults == params.config
+
+def test_blast_mt_mode_override(tmp_path):
+    """A user YAML can set blast_mt_mode (it must be a recognised default key,
+    or the config merge would reject it). Default is 1; here we override to 0."""
+    user_config_path = tmp_path / "user_config.yaml"
+    with open(user_config_path, 'w') as f:
+        yaml.dump({"blast_mt_mode": 0}, f)
+
+    parser = ScreenArgumentParser()
+    add_args(parser)
+    args = parser.parse_args([INPUT_QUERY, "--config", str(user_config_path)])
+    params = ScreenIO(args)
+
+    assert params.config["blast_mt_mode"] == 0
 
 def test_missing_default_config():
     """Test that missing default config raises appropriate error"""

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -198,6 +198,21 @@ def test_blast_mt_mode_override(tmp_path):
 
     assert params.config["blast_mt_mode"] == 0
 
+def test_blast_mt_mode_invalid_rejected(tmp_path):
+    """setup() must reject a blast_mt_mode that isn't one of the valid BLAST
+    multithreading modes (0, 1, 2)."""
+    user_config_path = tmp_path / "user_config.yaml"
+    with open(user_config_path, 'w') as f:
+        yaml.dump({"blast_mt_mode": 3}, f)
+
+    parser = ScreenArgumentParser()
+    add_args(parser)
+    args = parser.parse_args([INPUT_QUERY, "--config", str(user_config_path)])
+    params = ScreenIO(args)
+
+    with pytest.raises(RuntimeError, match="blast_mt_mode"):
+        params.setup()
+
 def test_missing_default_config():
     """Test that missing default config raises appropriate error"""
     with patch("importlib.resources.files") as mock_files:


### PR DESCRIPTION
Following from #124, but manages mt_mode through a yml, and so addresses the cli cruftyness issue. Let me know what you think.