### PR TITLE
Vectorise the NC coordinate calculations for check_reg_path

### DIFF
--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -147,15 +147,13 @@ def parse_taxonomy_hits(
 
         # If NT Taxonomy, we have some additional parsing to consider...
         if step == ScreenStep.TAXONOMY_NT:
-            unique_query_data["q. start"] = [query_info.nc_to_nt_query_coords(
-                                                row["q. start"],
-                                                int(row["query acc."].split("_")[-1])
-                                            ) for _, row in unique_query_data.iterrows()]
-            unique_query_data["q. end"] = [query_info.nc_to_nt_query_coords(
-                                            row["q. end"],
-                                            int(row["query acc."].split("_")[-1])
-                                        ) for _, row in unique_query_data.iterrows()]
             nc_id = int(query_acc.split("_")[-1])
+            unique_query_data["q. start"] = unique_query_data["q. start"].apply(
+                query_info.nc_to_nt_query_coords, index=nc_id
+            )
+            unique_query_data["q. end"] = unique_query_data["q. end"].apply(
+                query_info.nc_to_nt_query_coords, index=nc_id
+            )
             start, stop = query_info.non_coding_regions[nc_id]
             logger.info("    for the non-coding region: %s-%s", start, stop)
 


### PR DESCRIPTION
## Background
There was an issue with some entries of a multiquery fasta input being missed as flags, which also brought up a incorrect write warning with copies of dataframes from pandas. This ensures that intead of iterrows we use vectorisation of the non-coding coordinate calculations which is a much better way to handle it and may of addressed the error, subject to a repeat test on another machine.