### PR TITLE
Bugfix filter out lowconcern protein e-values

### DIFF
--- a/commec/screeners/check_low_concern.py
+++ b/commec/screeners/check_low_concern.py
@@ -360,6 +360,8 @@ def parse_low_concern_hits(protein_handler : HmmerHandler,
     low_concern_protein_screen_data = protein_handler.read_output()
     append_nt_querylength_info(low_concern_protein_screen_data, queries)
     recalculate_hmmer_query_coordinates(low_concern_protein_screen_data)
+    low_concern_protein_screen_data = low_concern_protein_screen_data[
+        low_concern_protein_screen_data["evalue"] < LOW_CONCERN_PROTEIN_EVALUE_CUTOFF]
     logger.debug("\tLow-concern Protein Data: shape: %s preview:\n%s",
                  low_concern_protein_screen_data.shape, low_concern_protein_screen_data.head())
     

--- a/commec/screeners/check_low_concern.py
+++ b/commec/screeners/check_low_concern.py
@@ -358,10 +358,10 @@ def parse_low_concern_hits(protein_handler : HmmerHandler,
     """
     # Reading empty outcomes should result in empty DataFrames, not errors.
     low_concern_protein_screen_data = protein_handler.read_output()
-    append_nt_querylength_info(low_concern_protein_screen_data, queries)
-    recalculate_hmmer_query_coordinates(low_concern_protein_screen_data)
     low_concern_protein_screen_data = low_concern_protein_screen_data[
         low_concern_protein_screen_data["evalue"] < LOW_CONCERN_PROTEIN_EVALUE_CUTOFF]
+    append_nt_querylength_info(low_concern_protein_screen_data, queries)
+    recalculate_hmmer_query_coordinates(low_concern_protein_screen_data)
     logger.debug("\tLow-concern Protein Data: shape: %s preview:\n%s",
                  low_concern_protein_screen_data.shape, low_concern_protein_screen_data.head())
     


### PR DESCRIPTION
## Background
Back in 17ad6ce, during a rework of the then "benign" step, the evalue filter cutoff for low concern proteins was refactored into one of the global constants, but the original line that did the filtering logic on the dataframe was lost. This restores the filter operation.

**Issues**:
Low concern protein hits of any evalue are being accepted to clear flagged hits from the best match searched.

## Changes
Simply filters the incoming low concern protein hits by evalue after import.

### Bug fixes
* Low concern protein hits are only used to clear flags when at an appropriately thresholded e-value.